### PR TITLE
Enemies can remotely activate some items

### DIFF
--- a/Game/KDTypeDefs.ts
+++ b/Game/KDTypeDefs.ts
@@ -691,6 +691,10 @@ interface enemy extends KDHasTags {
 	remote?: number,
 	/** */
 	remoteAmount?: number,
+	/** If the enemy has a remote that can control punishing items (e.g. shock collars), the range that they can control items from */
+	punishRemote?: number,
+	/** The chance per tick that the enemy will use their remote remote to punish the player when they are within range */
+	punishRemoteChance?: number,
 	/** */
 	bypass?: boolean,
 	/** */
@@ -929,6 +933,8 @@ interface KinkyDungeonEvent {
 	humanOnly?: boolean;
 	/** Distance having to do with stealth */
 	distStealth?: number;
+	/** Dialogue key an enemy should send */
+	enemyDialogue?: string;
 
 	// MUTABLE QUANTITIES
 	prevSlowLevel?: number;

--- a/Game/KinkyDungeonEnemies.js
+++ b/Game/KinkyDungeonEnemies.js
@@ -3414,6 +3414,9 @@ function KinkyDungeonEnemyLoop(enemy, player, delta, visionMod, playerItems) {
 		if (AIData.vibe || (enemy.Enemy.remote && AIData.playerDist < enemy.Enemy.remote)) {
 			KinkyDungeonSendEvent("remoteVibe", {enemy: enemy.Enemy.name, power: enemy.Enemy.remoteAmount ? enemy.Enemy.remoteAmount : 5, overcharge: AIData.vibe, noSound: AIData.vibe});
 		}
+		if (AIData.aggressive && AIData.canSensePlayer && enemy.Enemy.punishRemote && AIData.playerDist < enemy.Enemy.punishRemote) {
+			KinkyDungeonSendEvent("remotePunish", {enemy});
+		}
 	}
 
 	if (enemy.IntentAction && KDIntentEvents[enemy.IntentAction] && KDIntentEvents[enemy.IntentAction].maintain) {
@@ -4086,4 +4089,21 @@ function KinkyDungeonGetLoadoutForEnemy(enemy, guaranteed) {
 	}
 	if (loadout_list.length > 0) return loadout_list[Math.floor(KDRandom() * loadout_list.length)];
 	return "";
+}
+
+/**
+ * Gets the text for a key, suffixed with the enemy faction or name if available. Otherwise falls back to just the key
+ * @param {string} key - The base text key
+ * @param {entity} enemy - The enemy
+ * @param {boolean} useName - Whether to use the enemy name or faction
+ * @returns {string}
+ */
+function KinkyDungeonGetTextForEnemy(key, enemy, useName = false) {
+	const enemyKey = `${key}${useName ? enemy.Enemy.name : enemy.Enemy.faction}`;
+	let text = TextGet(enemyKey);
+	if (!text || text.endsWith(enemyKey)) {
+		// Couldn't find enemy-specific text - fall back to just the key
+		text = TextGet(key);
+	}
+	return text;
 }

--- a/Game/KinkyDungeonEnemiesList.js
+++ b/Game/KinkyDungeonEnemiesList.js
@@ -472,7 +472,7 @@ let KinkyDungeonEnemies = [
 		summon: [
 			{enemy: "Drone", range: 2, count: 2, chance: 0.25, strict: true},],
 		armor: 2, maxhp: 10, movePoints: 2,
-		visionRadius: 6, followRange: 1, projectileAttack: true, useLock: "Red",
+		visionRadius: 6, followRange: 1, projectileAttack: true, useLock: "Red", punishRemote: 4, punishRemoteChance: 0.25,
 		attack: "MeleeBindWill", attackPoints: 4, attackWidth: 3, tilesMinRange: 2, attackRange: 2, power: 3, dmgType: "crush", multiBind: 2,
 		minLevel:3, weight:-6, terrainTags: {"secondhalf":1, "thirdhalf":1, "increasingWeight":0.5, "metalAnger": 6, "metalRage": 4, "robot": 10}, shrines: ["Metal"], allFloors: true,
 		dropTable: [{name: "Gold", amountMin: 10, amountMax: 20, weight: 10, noSummon: true}]},
@@ -491,7 +491,7 @@ let KinkyDungeonEnemies = [
 		summon: [
 			{enemy: "Drone", range: 2, count: 2, chance: 0.25, strict: true},],
 		armor: 2, maxhp: 24, movePoints: 4,
-		visionRadius: 16, followRange: 1, projectileAttack: true, useLock: "Red",
+		visionRadius: 16, followRange: 1, projectileAttack: true, useLock: "Red", punishRemote: 6, punishRemoteChance: 0.5,
 		attack: "SpellMeleeBindWill", attackPoints: 2, attackWidth: 1, attackRange: 3, power: 1, dmgType: "crush", multiBind: 1, fullBoundBonus: 2,
 		minLevel:9, weight:-106, terrainTags: {"thirdhalf":1, "increasingWeight":0.5, "open": 100, "metalAnger": 44, "metalRage": 13, "robot": 6}, shrines: ["Metal"], allFloors: true,
 		dropTable: [{name: "Gold", amountMin: 20, amountMax: 30, weight: 10, noSummon: true}]},
@@ -511,7 +511,7 @@ let KinkyDungeonEnemies = [
 	{name: "Wolfgirl", faction: "Nevermere", clusterWith: "wolfgirl", bound: "Wolfgirl", color: "#00EFAB", tags: KDMapInit(["leashing", "imprisonable", "trainer", "wolfgirl", "jailer", "opendoors", "unflinching", "closedoors", "wolfRestraints", "melee", "elite", "unflinching", "glueweakness", "ticklesevereweakness", "slashweakness", "pierceweakness", "unflinching", "jail", "hunter"]), followRange: 1,
 		summon: [
 			{enemy: "WolfgirlPet", range: 2, count: 1, chance: 0.7, strict: true},],
-		spells: ["RestrainingDevice"], spellCooldownMult: 1, spellCooldownMod: 1, AI: "hunt",  visionRadius: 10, maxhp: 22, minLevel:0, weight:-6, movePoints: 2, disarm: 0.5,
+		spells: ["RestrainingDevice"], spellCooldownMult: 1, spellCooldownMod: 1, AI: "hunt",  visionRadius: 10, maxhp: 22, minLevel:0, weight:-6, movePoints: 2, disarm: 0.5, punishRemote: 4, punishRemoteChance: 0.25,
 		attackPoints: 3, attack: "MeleeBindLockAllWillSpell", attackWidth: 3, attackRange: 1, tilesMinRange: 1, power: 4, dmgType: "grope", sneakThreshold: 1, attackLock: "Red",
 		terrainTags: {"secondhalf":3, "lastthird":5, "metalAnger": 9, "metalRage": 5, "wolfgirl": 7}, allFloors: true, shrines: ["Metal"],
 		dropTable: [{name: "Gold", amountMin: 15, amountMax: 20, weight: 10}, {name: "EscortDrone", weight: 0.25, ignoreInInventory: true}, {name: "RedKey", weight: 9}]},
@@ -1301,11 +1301,11 @@ let KinkyDungeonEnemies = [
 		terrainTags: {"jailGuard": 15, "Guard": 1}, allFloors: true, disarm: 0.5, evasion: -0.5, focusPlayer: true,
 		dropTable: [{name: "Pick", weight: 15}, {name: "RedKey", weight: 5}, {name: "SmokeBomb", weight: 7}, {name: "ScrollArms", weight: 1}, {name: "ScrollVerbal", weight: 1}, {name: "ScrollLegs", weight: 1}], rep: {"Prisoner": 5}},
 	{name: "Guard", faction: "Jail", bound: "Guard", tags: KDMapInit(["leashing", "opendoors", "closedoors", "miniboss", "jailer", "melee", "shackleRestraints", "jailRestraints", "guardCall"]), noDisplace: true, keys: true, followRange: 1, AI: "guard", visionRadius: 6, disarm: 0.5,
-		maxhp: 12, minLevel: -1, weight:-1000, movePoints: 1, attackPoints: 3, attack: "MeleeBindLockAllWill", attackWidth: 1, attackRange: 1, power: 2, dmgType: "grope", fullBoundBonus: 2, evasion: -0.5, focusPlayer: true, attackLock: "Red",
+		maxhp: 12, minLevel: -1, weight:-1000, movePoints: 1, attackPoints: 3, attack: "MeleeBindLockAllWill", attackWidth: 1, attackRange: 1, power: 2, dmgType: "grope", fullBoundBonus: 2, evasion: -0.5, focusPlayer: true, attackLock: "Red", punishRemote: 3, punishRemoteChance: 0.15,
 		terrainTags: {"Guard": 1010}, allFloors: true, dropTable: [{name: "RedKey", weight: 1}], rep: {"Prisoner": 10}},
 	{name: "GuardHeavy", faction: "Jail", bound: "GuardHeavy", tags: KDMapInit(["leashing", "opendoors", "closedoors", "jailer", "melee", "unflinching", "hunter", "guardCall", "miniboss", "shackleRestraints", "handcuffer", "jailRestraints"]), noDisplace: true, disarm: 0.5,
 		keys: true, followRange: 1, AI: "guard", visionRadius: 7, maxhp: 12, minLevel: 4, weight:-20, movePoints: 1, attackPoints: 2, evasion: -0.5, focusPlayer: true,
-		attack: "MeleeBindLockAllWillStun", attackWidth: 3, attackRange: 1, power: 5, dmgType: "electric", stunTime: 1, attackLock: "Red",
+		attack: "MeleeBindLockAllWillStun", attackWidth: 3, attackRange: 1, power: 5, dmgType: "electric", stunTime: 1, attackLock: "Red", punishRemote: 4, punishRemoteChance: 0.2,
 		terrainTags: {"jailGuard": 22, "increasingWeight": 1, "jailbreak": 28}, allFloors: true, dropTable: [{name: "RedKey", weight: 1}], rep: {"Prisoner": 10}},
 
 

--- a/Game/KinkyDungeonRestraints.js
+++ b/Game/KinkyDungeonRestraints.js
@@ -2389,9 +2389,10 @@ let KinkyDungeonCancelFlag = false;
  * @param {string} [faction]
  * @param {item} [dynamicLink]
  * @param {string} [Curse] - Curse to apply
+ * @param {boolean} [autoMessage] - Whether or not to automatically dispatch messages
  * @returns
  */
-function KinkyDungeonAddRestraint(restraint, Tightness, Bypass, Lock, Keep, Link, SwitchItems, events, faction, Unlink, dynamicLink, Curse) {
+function KinkyDungeonAddRestraint(restraint, Tightness, Bypass, Lock, Keep, Link, SwitchItems, events, faction, Unlink, dynamicLink, Curse, autoMessage = true) {
 	KDStruggleGroupLinkIndex = {};
 	let start = performance.now();
 	let tight = (Tightness) ? Tightness : 0;
@@ -2405,7 +2406,7 @@ function KinkyDungeonAddRestraint(restraint, Tightness, Bypass, Lock, Keep, Link
 			let linked = false;
 			if (linkable) {
 				linked = true;
-				KinkyDungeonCancelFlag = KinkyDungeonLinkItem(restraint, r, Tightness, Lock, Keep, faction, Curse);
+				KinkyDungeonCancelFlag = KinkyDungeonLinkItem(restraint, r, Tightness, Lock, Keep, faction, Curse, autoMessage);
 			}
 
 			let eventsAdd = false;
@@ -2776,9 +2777,10 @@ function KinkyDungeonRestraintTypes(ShrineFilter) {
  * @param {boolean} [Keep]
  * @param {string} [faction]
  * @param {string} [Curse]
+ * @param {boolean} [autoMessage] - Whether or not to automatically dispatch a message
  * @returns {boolean}
  */
-function KinkyDungeonLinkItem(newRestraint, oldItem, tightness, Lock, Keep, faction, Curse) {
+function KinkyDungeonLinkItem(newRestraint, oldItem, tightness, Lock, Keep, faction, Curse, autoMessage = true) {
 	if (newRestraint && oldItem && oldItem.type == Restraint) {
 		if (newRestraint) {
 			KinkyDungeonAddRestraint(newRestraint, tightness, true, Lock, Keep, true, undefined, undefined, faction, undefined, oldItem, Curse);
@@ -2790,7 +2792,7 @@ function KinkyDungeonLinkItem(newRestraint, oldItem, tightness, Lock, Keep, fact
 				oldItem.events = Object.assign([], KDRestraint(oldItem).events);
 			}
 			KDUpdateLinkCaches(newItem);
-			if (KDRestraint(oldItem).Link)
+			if (autoMessage && KDRestraint(oldItem).Link)
 				KinkyDungeonSendTextMessage(7, TextGet("KinkyDungeonLink" + oldItem.name), "#ff0000", 2);
 			return true;
 		}

--- a/Game/KinkyDungeonRestraintsList.js
+++ b/Game/KinkyDungeonRestraintsList.js
@@ -287,7 +287,10 @@ const KinkyDungeonRestraints = [
 	{inventory: true, name: "WolfAnkleCuffs", accessible: true, Asset: "FuturisticAnkleCuffs", Link: "WolfAnkleCuffs2", DefaultLock: "Red", LinkableBy: [...KDBindable], Type: "Chained", Color: ['#4F91DE', '#4F91DE', '#3F6945', '#000000'], Group: "ItemFeet", hobble: true, power: 8, weight: 0,
 		escapeChance: {"Struggle": -0.5, "Cut": -0.4, "Remove": 0.4, "Pick": 0.15},
 		maxwill: 1.0, enemyTags: {"wolfRestraints":7}, playerTags: {"ItemFeetFull":-2}, minLevel: 0, allFloors: true, shrine: ["Metal", "Cuffs", "AnkleCuffsBase"],
-		events: [{trigger: "hit", type: "linkItem", sfx: "LightJingle", chance: 0.3, subMult: 0.5, noLeash: true}]},
+		events: [
+			{trigger: "hit", type: "linkItem", sfx: "LightJingle", chance: 0.3, subMult: 0.5, noLeash: true},
+			{trigger: "remotePunish", type: "RemoteLinkItem", sfx: "LightJingle", noLeash: true, enemyDialogue: "KDDialogueRemoteLinkCuffs", msg: "KDMsgRemoteLinkCuffs"},
+		]},
 	{name: "WolfAnkleCuffs2", accessible: true, Asset: "FuturisticAnkleCuffs", UnLink: "WolfAnkleCuffs", LinkableBy: ["AnkleCuffsBase", ...KDBindable], Type: "Closed", Color: ['#4F91DE', '#4F91DE', '#3F6945', '#000000'], Group: "ItemFeet", blockfeet: true, power: 8, weight: 0,
 		escapeChance: {"Struggle": -0.5, "Cut": -0.5, "Remove": 0.4, "Pick": 0.15},
 		enemyTags: {}, playerTags: {}, minLevel: 0, allFloors: true, shrine: ["Metal", "Cuffs"],
@@ -303,7 +306,8 @@ const KinkyDungeonRestraints = [
 		events: [
 			{trigger: "playerAttack", type: "PunishPlayer", chance: 0.25, stun: 2, warningchance: 1.0, damage: "electric", power: 2, sfx: "Shock", inheritLinked: true,},
 			{trigger: "beforeStruggleCalc", type: "ShockForStruggle", chance: 0.75, stun: 2, warningchance: 1.0, damage: "electric", power: 2, sfx: "Shock", bind: 0.2, inheritLinked: true,},
-			{trigger: "playerCast", type: "PunishPlayer", chance: 1.0, punishComponent: "Verbal", damage: "electric", power: 2, sfx: "Shock", inheritLinked: true,}
+			{trigger: "playerCast", type: "PunishPlayer", chance: 1.0, punishComponent: "Verbal", damage: "electric", power: 2, sfx: "Shock", inheritLinked: true,},
+			{trigger: "remotePunish", type: "RemoteActivatedShock", chance: 0.1, stun: 2, damage: "electric", power: 2, sfx: "Shock", noLeash: true, inheritLinked: true,}
 		]},
 	{inventory: true, removePrison: true, name: "WolfLeash", tether: 2.9, Asset: "CollarLeash", Color: "#44fF76", Group: "ItemNeckRestraints", leash: true, power: 1, weight: -99, harness: true,
 		escapeChance: {"Struggle": -0.3, "Cut": -0.2, "Remove": 0.4, "Pick": 0.35}, enemyTags: {"wolfRestraints":9}, playerTags: {"ItemNeckRestraintsFull":-2, "ItemNeckFull":999}, minLevel: 0, allFloors: true, shrine: []},

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -8547,3 +8547,10 @@ KDShoutHelp2,Your screams are muffled by your gag!
 KDShoutHelp3,You can hardly make a noise...
 
 KDArmorNoise,"*clink*"
+
+KinkyDungeonRemoteShock,You yelp as the EnemyName activates your RestraintName
+
+KDDialogueRemoteLinkCuffs,That should slow you down!
+KDDialogueRemoteLinkCuffsNevermere,Try running away now~
+KDDialogueRemoteLinkCuffsAncientRobot,Initiating prisoner lockdown protocol
+KDMsgRemoteLinkCuffs,Your RestraintName suddenly snap together as the EnemyName activates them

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -6822,7 +6822,7 @@ KDCategoryMap,World Generation
 KDCategoryStart,Starting Scenario
 KDCategoryBoss,Unlockable
 
-KDWeaponConfiscated,You hand over your weapon relucdevitantly...
+KDWeaponConfiscated,You hand over your weapon reluctantly...
 
 dLeave,(Leave)
 dPause,(...)


### PR DESCRIPTION
## Summary

Adds the ability for certain enemies to remotely activate functionality of "smart" devices when aggressive if the player is wearing them and in range (currently the shock functionality of the Training Collar and the link functionality of the Smart Training Cuffs), to give them a bit of an edge for players that are foolish enough to take them on whilst wearing training gear.

The enemies that can do this are:

* Wolfgirl Trainer
* Ancient Patrol Unit
* Ancient Enforcer Unit
* Guard
* Armed Guard

I wasn't sure "lore-wise" whether all of these enemies should have access or it should be a wolfgirl-only thing. Also, I'm very much still feeling my way around the code, so let me know if I've done anything stupid!

Also fixes a random typo in the prisoner weapon confiscation dialogue.