### PR TITLE
Perk: Savour the Taste

### DIFF
--- a/Game/KinkyDungeonConsumables.js
+++ b/Game/KinkyDungeonConsumables.js
@@ -281,5 +281,11 @@ function KinkyDungeonUseConsumable(Name, Quantity) {
 	if (KDConsumable(item.item).sfx) {
 		if (KinkyDungeonSound) AudioPlayInstantSoundKD(KinkyDungeonRootDirectory + "/Audio/" + KDConsumable(item.item).sfx + ".ogg");
 	}
+
+	if (KDConsumable(item.item).potion && KinkyDungeonStatsChoice.has("SavourTheTaste")) {
+		KinkyDungeonAdvanceTime(1);
+		KinkyDungeonSlowMoveTurns = 1;
+	}
+
 	return true;
 }

--- a/Game/KinkyDungeonPerks.js
+++ b/Game/KinkyDungeonPerks.js
@@ -189,6 +189,7 @@ let KinkyDungeonStatsPresets = {
 	"BondageLover": {category: "Kinky", id: 15, cost: -1},
 	"Undeniable": {category: "Kinky", id: "Undeniable", cost: -1},
 	"BoundPower": {category: "Combat", id: 40, cost: 3},
+	"SavourTheTaste": {category: "Combat", id: "SavourTheTaste", cost: -1},
 	"KillSquad": {category: "Enemies", id: 41, cost: -3, block: ["Conspicuous"]},
 	"Stealthy": {category: "Enemies", id: 38, cost: 0},
 	"Conspicuous": {category: "Enemies", id: 39, cost: -1, block: ["KillSquad"]},

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -209,6 +209,8 @@ KinkyDungeonStatDesc56,"Switching spells and casting from spellbook does not tak
 
 KinkyDungeonStat57,"Disorganized"
 KinkyDungeonStatDesc57,"Switching weapons, learning/choosing spells, and casting from spellbook takes 3 turns."
+KinkyDungeonStatSavourTheTaste,"Savour the Taste"
+KinkyDungeonStatDescSavourTheTaste,"Drinking a potion takes 2 turns"
 
 KinkyDungeonStatMagicHands,"Magic Hands"
 KinkyDungeonStatDescMagicHands,"Enemies can add restraints underneath existing restraints."


### PR DESCRIPTION
Quick one that turned out to be easier than I thought to implement. Adds a new perk called "Savour the Taste", which makes potion-drinking take a bit of extra time, to make it harder to use them to get yourself out of a pinch. I was somewhat tempted to make it all consumables, but potions felt most appropriate, given that they're most frequently used to get out of a pinch ("oops - I didn't realise I'd run out of MP - let me instantly down a mana potion"), and it would be a bit harsh to have a time delay on things like smoke bombs 😆.

I also haven't looked much into exactly what `KinkyDungeonSlowMoveTurns` does - I just copied what the Disorganized perk was doing, which seemed to work - let me know if that was a mistake!