### PR TITLE
Bugfix: Crash when certain enemies use command spell to unlock magic locks

### DIFF
--- a/Game/KinkyDungeonDialogue.js
+++ b/Game/KinkyDungeonDialogue.js
@@ -582,7 +582,8 @@ function KDAllyDialogue(name, requireTags, requireSingleTag, excludeTags, weight
 									KinkyDungeonLock(r, "");
 								}
 							}
-							KinkyDungeonCastSpell(KinkyDungeonPlayerEntity.x, KinkyDungeonPlayerEntity.y, KinkyDungeonFindSpell("EffectEnemyCM" + (enemy?.Enemy?.unlockCommandLevel || 1), true), undefined, undefined, undefined);
+							const unlockSpell = KinkyDungeonFindSpell("EffectEnemyCM" + (enemy?.Enemy?.unlockCommandLevel || 1), true) || KinkyDungeonFindSpell("EffectEnemyCM1", true);
+							KinkyDungeonCastSpell(KinkyDungeonPlayerEntity.x, KinkyDungeonPlayerEntity.y, unlockSpell, undefined, undefined, undefined);
 
 							if (KinkyDungeonSound) AudioPlayInstantSoundKD(KinkyDungeonRootDirectory + "/Audio/Magic.ogg");
 							KinkyDungeonSetEnemyFlag(enemy, "commandword", enemy.Enemy.unlockCommandCD || 90);


### PR DESCRIPTION
## Summary

A bit of a rare one. When pleading with certain magic enemies to unlock your purple-locked restraints, the game will crash if they actually agree to do so. This is due to the dialogue trying to find the spell `EffectEnemyCM2` (or 3 I guess, if it's even possible to convince Fuuka to unlock you), as they have a `unlockCommandLevel` which isn't 1, and there is no `EffectEnemyCM2` (yet?). Reproduced and tested the fix on Master Conjurer enemies, which have `unlockCommandLevel: 2`.

Obviously the other fix for this would be to set the `unlockCommandLevel` to 1 on those enemies (or remove it completely), but I assumed the intention was to at some point create the higher-level spells, so opted for this, which falls back to the level 1 spell if it can't find the spell corresponding to the enemy's unlock command level.