### PR TITLE
Make player transparent when bullets are travelling

### DIFF
--- a/Game/KinkyDungeon.js
+++ b/Game/KinkyDungeon.js
@@ -96,6 +96,7 @@ let KDToggles = {
 	ArousalHearts: true,
 	VibeHearts: true,
 	FancyWalls: true,
+	PlayerTransparencyDuringBullets: true,
 };
 
 let KDDefaultKB = {

--- a/Game/KinkyDungeonDraw.js
+++ b/Game/KinkyDungeonDraw.js
@@ -820,6 +820,7 @@ function KinkyDungeonDrawGame() {
 						(KinkyDungeonPlayerEntity.visual_x - CamX - CamX_offsetVis)*KinkyDungeonGridSizeDisplay, (KinkyDungeonPlayerEntity.visual_y - CamY - CamY_offsetVis)*KinkyDungeonGridSizeDisplay,
 						KinkyDungeonGridSizeDisplay, KinkyDungeonGridSizeDisplay, undefined, {
 							zIndex: 0.01,
+							alpha: KinkyDungeonGetPlayerTextureTransparency(),
 						});
 				}
 				if ((KinkyDungeonMovePoints < 0 || KinkyDungeonGetBuffedStat(KinkyDungeonPlayerBuffs, "SlowLevel") > 0) && KinkyDungeonSlowLevel < 10) {
@@ -1633,6 +1634,18 @@ function KinkyDungeonDrawGame() {
 
 }
 
+/**
+ * Determines transparency of the player.
+ * 
+ * @returns {number} - alpha transparency of the player
+ */
+function KinkyDungeonGetPlayerTextureTransparency() {
+	if (KDToggles.PlayerTransparencyDuringBullets && KDBulletWarnings.length > 0) {
+		return 0.5;
+	} else {
+		return 1;
+	}
+}
 
 /**
  * Draws arousal screen filter

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -46,6 +46,7 @@ KDToggleArousalHearts,Advanced Distraction VFX
 KDToggleVibeHearts,Advanced Toy VFX
 KDToggleShowNPCStatuses,Show NPC Status
 KDToggleFancyWalls,Advanced Fog of War
+KDTogglePlayerTransparencyDuringBullets,Projectiles Make Player Transparent
 KDToggleIntenseOrgasm,Intense 'Let Go' VFX
 KDToggleVibeSounds,Enable Toy SFX
 KDToggleFullscreen,Enable Fullscreen


### PR DESCRIPTION
This is a small change to increase visibility of whether projectiles will hit the player next turn.

Example with this on:
![image](https://github.com/Ada18980/KinkiestDungeon/assets/33641061/a42f527b-dba2-4261-ab5b-65be97cc7517)

Example with it off (how it is currently):
![image](https://github.com/Ada18980/KinkiestDungeon/assets/33641061/67e6edf4-d3ae-41a8-84d9-655321327b0a)

Options menu with the toggle:
![image](https://github.com/Ada18980/KinkiestDungeon/assets/33641061/0316f755-050e-4595-8b22-0eb67f010f52)

I'm not sure if 0.5 alpha is the best value if the options wording makes it very clear, so feel free to modify them. It feels a bit hacky to do this but at least it's easy to remove if we find a better solution.
