### PR TITLE
Fix Brawler perk not applying to Unarmed weapon

### DIFF
--- a/Game/KinkyDungeonDialogueList.js
+++ b/Game/KinkyDungeonDialogueList.js
@@ -113,10 +113,9 @@ let KDDialogue = {
 			"Accept": {gag: true, playertext: "WeaponFoundAccept", response: "GoodGirl", personalities: ["Dom", "Sub", "Robot"],
 				clickFunction: (gagged, player) => {
 					KinkyDungeonSendTextMessage(10, TextGet("KDWeaponConfiscated"), "#ff0000", 2);
-					let weapon = KinkyDungeonPlayerDamage.name;
-					if (weapon && weapon != "Unarmed") {
+					if (!isUnarmed(KinkyDungeonPlayerWeapon)) {
 						KinkyDungeonChangeRep("Ghost", 3);
-						let item = KinkyDungeonInventoryGetWeapon(weapon);
+						let item = KinkyDungeonInventoryGetWeapon(KinkyDungeonPlayerDamage.name);
 						KDSetWeapon(null);
 						KinkyDungeonAddLostItems([item], false);
 						KinkyDungeonInventoryRemove(item);

--- a/Game/KinkyDungeonFight.js
+++ b/Game/KinkyDungeonFight.js
@@ -183,7 +183,7 @@ function KinkyDungeonGetPlayerWeaponDamage(HandsFree, NoOverride) {
 	} else if (handBondage && (flags.KDDamageHands || weapon.unarmed) && (!weapon || !weapon.noHands || weapon.unarmed)) {
 		KinkyDungeonPlayerDamage.chance *= 0.5 + Math.max(0, 0.5 * Math.min(1, handBondage));
 	}
-	if (KinkyDungeonStatsChoice.get("Brawler") && !KinkyDungeonPlayerDamage.name) {
+	if (KinkyDungeonStatsChoice.get("Brawler") && isUnarmed(KinkyDungeonPlayerDamage)) {
 		KinkyDungeonPlayerDamage.dmg += KDBrawlerAmount;
 	} else {
 		if (KinkyDungeonSlowLevel > 1 && (!KinkyDungeonPlayerDamage.name || weapon.unarmed)) {
@@ -195,6 +195,13 @@ function KinkyDungeonGetPlayerWeaponDamage(HandsFree, NoOverride) {
 	}
 
 	return KinkyDungeonPlayerDamage;
+}
+/**
+ * @param {weapon} weapon 
+ * @returns true if the weapon represents Unarmed
+ */
+function isUnarmed(weapon) {
+	return !weapon || !weapon.name || weapon.name == "Unarmed";
 }
 
 

--- a/Game/KinkyDungeonInventory.js
+++ b/Game/KinkyDungeonInventory.js
@@ -83,7 +83,7 @@ function KinkyDungeonHandleInventory() {
 			//KinkyDungeonAttemptConsumable(item.name, 1);
 		} else if (KinkyDungeonCurrentFilter == Weapon) {
 			let weapon = ((filteredInventory[KinkyDungeonCurrentPageInventory] != null) ? filteredInventory[KinkyDungeonCurrentPageInventory].name : null);
-			if (weapon && weapon != "Unarmed") {
+			if (!isUnarmed(weapon)) {
 				let equipped = weapon == KinkyDungeonPlayerWeapon;
 				if (MouseIn(canvasOffsetX_ui + 640*KinkyDungeonBookScale + 25, canvasOffsetY_ui + 483*KinkyDungeonBookScale, 350, 60) && !equipped) {
 					KDSendInput("switchWeapon", {weapon: weapon});


### PR DESCRIPTION
Right now, the Brawler perk (which increases Unarmed damage by 10) doesn't apply a damage increase if you switch weapons and then choose Unarmed from the quick inventory icon to switch back.

Looking at the code `if (KinkyDungeonStatsChoice.get("Brawler") && !KinkyDungeonPlayerDamage.name) {` wasn't checking for weapon named "Unarmed" like it does in other areas.

I've fixed this and added a helper function.