### PR TITLE
 TempPoses should be included when checking post or tags

### DIFF
--- a/Data/Poses.ts
+++ b/Data/Poses.ts
@@ -328,7 +328,7 @@ function CheckPoseOrTags(C: Character, tag: string) {
 	if (KDCurrentModels.get(C)?.Poses[tag]) {
 		return true;
 	}
-	if (KDCurrentModels.get(C)?.TempPoses[tag]) {
+	if (KDCurrentModels.get(C)?.TempPoses && KDCurrentModels.get(C)?.TempPoses[tag]) {
 		return true;
 	}
 	return false;

--- a/Data/Poses.ts
+++ b/Data/Poses.ts
@@ -328,6 +328,9 @@ function CheckPoseOrTags(C: Character, tag: string) {
 	if (KDCurrentModels.get(C)?.Poses[tag]) {
 		return true;
 	}
+	if (KDCurrentModels.get(C)?.TempPoses[tag]) {
+		return true;
+	}
 	return false;
 }
 


### PR DESCRIPTION
Because tags such as "PreferWristtie" is added to TempPoses only (not added to Poses) in KDDress Line 399, and the allowed arm poses are calculated (in Line 406) without TempPoses, these tags never have any effects.