### PR TITLE
Feat : auto format translation file

### DIFF
--- a/.github/scripts/format-translation-script.py
+++ b/.github/scripts/format-translation-script.py
@@ -49,25 +49,27 @@ def write_translated_file(csv_lines : list, translations : list, output_path : s
     translated = set()
     with open(output_path, 'w', encoding='utf-8') as file:
         for line in csv_lines:
-            if (line is None) or (not line[1]):
-                file.write('\n')  
+            if not line or not line[1]:
+                file.write('\n')
                 continue
             
             key, original, *_ = line
             
             if original in translated:
-                # Not sure if it is better to mark
-                # file.write(f'<!REPEAT> {original}\n')
                 continue
                 
             translated.add(original)
             
-            # The next line of the original text corresponding to the List is the translation. If the translation is not found, use "# Original" instead.
-            original_index = translations.index(original) if original in translations else -1
-            if original_index == -1:
+            # The next line of the original text corresponding to the List is the translation. If the translation is not found,will use "### Original" instead.
+            try:
+                original_index = translations.index(original)
+                translation = translations[original_index + 1].strip()
+                if not translation:
+                    raise ValueError
+            except (ValueError, IndexError):
                 file.write(f'### {original}\n')
                 continue
-            translation = translations[original_index + 1]
+            
             file.write(f'{original}\n{translation}\n')
 
 original_csv_path = 'Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv'
@@ -88,10 +90,10 @@ modified_files = sys.argv[1:]
 print(f'Modified Files: {modified_files}')
 
 # if originnal file is modified, then all translation files need to be reformatted
-if original_csv_path in modified_files:
+if any(file.endswith('Text_KinkyDungeon.csv') for file in modified_files):
     modified_files = translation_files
 
-modified_files = [file for file in modified_files if file in translation_files]
+modified_files = [file for file in modified_files if file.endswith('.txt')]
 
 csv_lines = read_csv_with_empty_lines(original_csv_path)
 

--- a/.github/scripts/format-translation-script.py
+++ b/.github/scripts/format-translation-script.py
@@ -1,0 +1,105 @@
+# This script is used to reorder and deduplicate the translation files according to the order of the source text files. Doing so has the following effects:
+# - For merging PRs in the future, the translation content supports insertion at any position, and the script will automatically reorder and retain the first non-repeated translation content.(You can rest assured to cover the content)
+# - If the source text in the source file is modified in the future, the script will not retain the old translation content in the translation file, reducing the generation of obsolete translation content.
+# - Use `### Original` instead of untranslated original text lines to facilitate translators to find and compare untranslated content, and translators do not need to open the source file for copying, improving work efficiency.
+# - Retain the empty lines and order of the original file, so that the translation work can be browsed according to the classification of the original file.
+# - Remove duplicate content in the translation file to avoid repeated translation.
+#
+# Git-Action automation configuration:
+# This script has been configured in Git-Action. When the translation file or source text file changes, the action is automatically triggered to execute the reorder overwrite operation.
+#
+# Operation process:
+# - Read the Text_KinkyDungeon.csv file and retain empty lines and order.
+# - Read the Text_KinkyDungeon_[lang].txt file and store the content in a list.
+# - Reorder the content of the translation file according to the order of the Text_KinkyDungeon.csv file
+#     - If there is no corresponding translation, use `### Original` instead
+#     - If there is duplicate translation, it will not be written
+
+import os
+import csv
+import sys
+
+# Read the csv file
+def read_csv_with_empty_lines(file_path) -> list:
+    with open(file_path, newline='', encoding='utf-8') as csvfile:
+        reader = csv.reader(csvfile)
+        lines = []
+        for row in reader:
+            # Retain empty lines
+            if not row:
+                lines.append(None)
+                continue
+                
+            if len(row) != 2:
+                print(f'<ABNORMAL> {row}')
+                continue
+                
+            lines.append(row)
+        return lines
+    
+
+# Read the translation file
+def read_translation_file(file_path) -> list:
+    with open(file_path, 'r', encoding='utf-8') as file:
+        lines = [line.strip() for line in file.readlines()]
+    return lines
+
+
+def write_translated_file(csv_lines : list, translations : list, output_path : str):
+    translated = set()
+    with open(output_path, 'w', encoding='utf-8') as file:
+        for line in csv_lines:
+            if (line is None) or (not line[1]):
+                file.write('\n')  
+                continue
+            
+            key, original, *_ = line
+            
+            if original in translated:
+                # Not sure if it is better to mark
+                # file.write(f'<!REPEAT> {original}\n')
+                continue
+                
+            translated.add(original)
+            
+            # The next line of the original text corresponding to the List is the translation. If the translation is not found, use "# Original" instead.
+            original_index = translations.index(original) if original in translations else -1
+            if original_index == -1:
+                file.write(f'### {original}\n')
+                continue
+            translation = translations[original_index + 1]
+            file.write(f'{original}\n{translation}\n')
+
+original_csv_path = 'Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv'
+
+# Enable the translation files to be reordered
+translation_files = [
+    'Text_KinkyDungeon_CN.txt',
+    'Text_KinkyDungeon_DE.txt',
+    'Text_KinkyDungeon_KR.txt',
+    'Text_KinkyDungeon_RU.txt',
+    'Text_KinkyDungeon_JP.txt',
+    'Text_KinkyDungeon_ES.txt',
+    ]
+translation_files = [f'Screens/MiniGame/KinkyDungeon/{file}' for file in translation_files]
+
+
+modified_files = sys.argv[1:]
+print(f'Modified Files: {modified_files}')
+
+# if originnal file is modified, then all translation files need to be reformatted
+if original_csv_path in modified_files:
+    modified_files = translation_files
+
+modified_files = [file for file in modified_files if file in translation_files]
+
+csv_lines = read_csv_with_empty_lines(original_csv_path)
+
+for file in modified_files:
+    if not os.path.exists(file):
+        print(f'File not found: {file}')
+        continue
+    
+    print(f'Processing : {file}')
+    translations = read_translation_file(file)
+    write_translated_file(csv_lines, translations, file)

--- a/.github/workflows/format-translation.yml
+++ b/.github/workflows/format-translation.yml
@@ -1,0 +1,44 @@
+name: Format Translation
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - newartwork
+    paths:
+      - 'Screens/MiniGame/KinkyDungeon/*'
+  pull_request:
+    branches:
+      - newartwork
+    paths:
+      - 'Screens/MiniGame/KinkyDungeon/*'
+ 
+jobs:
+  format-translation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+            fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+          
+      - name: 🚀 Run format-translation script
+        run: python .github/scripts/format-translation-script.py Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+  
+      - name: 📝 Commit changes 
+        id: check_changes 
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "format-translation-action"
+          git add . 
+          git diff-index --quiet HEAD || git commit -m "Format translation files"
+          git push

--- a/.github/workflows/format-translation.yml
+++ b/.github/workflows/format-translation.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-            fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v3


### PR DESCRIPTION
This script is used to reorder and deduplicate the translation files according to the order of the source text files. Doing so has the following effects:
- For merging PRs in the future, the translation content supports insertion at any position, and the script will automatically reorder and retain the first non-repeated translation content.(You can rest assured to cover the content)
- If the source text in the source file is modified in the future, the script will not retain the old translation content in the translation file, reducing the generation of obsolete translation content.
- Use `### Original` instead of untranslated original text lines to facilitate translators to find and compare untranslated content, and translators do not need to open the source file for copying, improving work efficiency.
- Retain the empty lines and order of the original file, so that the translation work can be browsed according to the classification of the original file.
- Remove duplicate content in the translation file to avoid repeated translation.
- You can get a clean and beautiful file

#### Git-Action automation configuration:
This script has been configured in Git-Action. When the translation file or source text file changes, the action is automatically triggered to execute the reorder overwrite operation.
(This action is only available in the Newartwork branch)

#### Operation process:
- Read the Text_KinkyDungeon.csv file and retain empty lines and order.
- Read the Text_KinkyDungeon_[lang].txt file and store the content in a list.
- Reorder the content of the translation file according to the order of the Text_KinkyDungeon.csv file
    - If there is no corresponding translation, use `### Original` instead
    - If there is duplicate translation, it will not be written


### demo \(branch [feat-RUNDEMO_auto_format_translation_action](https://github.com/Nacosia/KinkiestDungeon/tree/feat-RUNDEMO_auto_format_translation_action)\)
- Processed file : [Text_KinkyDungeon_CN.txt](https://github.com/Nacosia/KinkiestDungeon/blob/feat-RUNDEMO_auto_format_translation_action/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt)
- all commit change: [06fad55](https://github.com/Nacosia/KinkiestDungeon/commit/06fad550630c75d9b154a3751cf80f488524a871)

If you want to test this script, please use the command `python .github/scripts/format-translation-script.py Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv` locally.



\@https://github.com/Ada18980/KinkiestDungeon/issues/125
