### PR TITLE
[Please merge this PR before other translation files] Fix auto formatting translation some issue

### DIFF
--- a/.github/scripts/format-translation-script.py
+++ b/.github/scripts/format-translation-script.py
@@ -41,7 +41,7 @@ def read_csv_with_empty_lines(file_path) -> list:
 # Read the translation file
 def read_translation_file(file_path) -> list:
     with open(file_path, 'r', encoding='utf-8') as file:
-        lines = [line.strip() for line in file.readlines()]
+        lines = [ line.strip() for line in file.readlines() if not line.lstrip().startswith('###') ]
     return lines
 
 
@@ -61,10 +61,11 @@ def write_translated_file(csv_lines : list, translations : list, output_path : s
             translated.add(original)
             
             # The next line of the original text corresponding to the List is the translation. If the translation is not found,will use "### Original" instead.
+            # When the translation is the same as the original text, "### Original" is also used because it is meaningless.
             try:
                 original_index = translations.index(original)
                 translation = translations[original_index + 1].strip()
-                if not translation:
+                if not translation or (original == translation) :
                     raise ValueError
             except (ValueError, IndexError):
                 file.write(f'### {original}\n')

--- a/.github/workflows/format-translation.yml
+++ b/.github/workflows/format-translation.yml
@@ -10,12 +10,7 @@ on:
       - newartwork
     paths:
       - 'Screens/MiniGame/KinkyDungeon/*'
-  pull_request:
-    branches:
-      - newartwork
-    paths:
-      - 'Screens/MiniGame/KinkyDungeon/*'
- 
+
 jobs:
   format-translation:
     runs-on: ubuntu-latest

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt
@@ -19901,8 +19901,6 @@ Appointing managers increases the efficiency of other facilities.
 任命管理人员可以提高其他设施的效率。
 Total Efficiency Boost: AMNT
 总体效率提升: AMNT
-Restart required!
-需要重启！
 Domit
 支配者
 Beginner: Get a save code every 3 levels, autosave after each floor

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_ES.txt
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_ES.txt
@@ -9560,12 +9560,8 @@ You wriggle uselessly, tormented by the massive plugs inside of you!
 ¡Te retuerces inútilmente, atormentado por los enormes tapones dentro de ti!
 You climb into the grate
 Te subes a la rejilla
-Mmmph...
-Mmmm...
-Mmmmmmmmm...
-Mmmmmmmmm...
-Hhmmpphh...
-Hmmmpphh...
+
+
 Gghhhh!!!
 ¡¡¡Gghhhh!!!
 Mmmmmphh!!!
@@ -9582,16 +9578,12 @@ Mmmmmmmmm~
 Mmmmmmmmm~
 Unnnghhh...
 Unnnghhh...
-Mmmmmmmphhh..
-Mmmmmmmmm..
-Mmmmmphh~
-Mmmmmmm~
+
+
 Mmm~
 Mmm~
-Mmmmm~~
-Mmmmm~~
-Mmmmmm~~~
-Mmmmm~~~
+
+
 You are blinded!
 ¡Estás ciego!
 You took DamageDealt damage!
@@ -11306,14 +11298,12 @@ Nice and tight!
 ¡Agradable y apretado!
 Mmmmph!!!
 ¡¡¡Mmmmmmm!!!
-Mmmmm~
-Mmmmm~
+
 Mmmgh!
 ¡Mmm!
 Mmmmmm <3
 Hmmmm <3
-Mmmmmm~
-Mmmmm~
+
 Mmmph~
 mmmmm~
 *looks at you nervously*
@@ -11344,10 +11334,8 @@ Wwwmmmthhh!
 ¡Wwwmmmthhh!
 Mmmmmph!
 ¡Mmmmmmm!
-Mmmph.
-Mmmm.
-Mmmph!
-Mmmph!
+
+
 *looks at you suspiciously*
 *te mira con suspicacia*
 *looks at you angrily*
@@ -11368,38 +11356,28 @@ Mmmph!!!
 *risitas*
 Mmmph.
 Mmmm.
-Nngghhh!
-Nngghhhh!
-Mmm-hmmm.
-Mmm-hmmm.
-Mmmmmmm~
-Mmmmmmm~
-Mmmph~
-mmmmm~
+
+
+
+
 Mmmmph!!!
 ¡¡¡Mmmmmmm!!!
-Mmmmm~
-Mmmmm~
+
 Mmmgh!
 ¡Mmm!
 Mmmmmm <3
 Hmmmm <3
-Mmmmmm~
-Mmmmm~
-Mmmph~
-mmmmm~
-*Mmmmmm~*
-*Mmmmm~*
+
+
+
 *muffled giggle*
 *risita ahogada*
-Mmmm~
-Mmmm~
+
 Mmmph?
 ¿Mmm?
 Mmmghgh!!!
 ¡¡¡Mmmghgh!!!
-Mmmmph...
-Mmmmmm...
+
 Hhhhmph!
 ¡Hhhhmph!
 Mmmmmmmmm...
@@ -11416,8 +11394,7 @@ Wwwmmmthhh!
 ¡Wwwmmmthhh!
 Mmmmmph!
 ¡Mmmmmmm!
-Mmmph.
-Mmmm.
+
 Mmmph!
 Mmmph!
 Mmmph?
@@ -11438,16 +11415,14 @@ Mmmph!!!
 ¡¡¡Mmmmm!!!
 *muffled giggle*
 *risita ahogada*
-Mmmph.
-Mmmm.
+
 Nngghhh!
 Nngghhhh!
 Mmm-hmmm.
 Mmm-hmmm.
 Mmmmmmm~
 Mmmmmmm~
-Mmmph~
-mmmmm~
+
 You'll never catch me!
 ¡Nunca me atraparás!
 Where'd you come from?
@@ -15646,8 +15621,7 @@ Exciting!
 ¡Emocionante!
 That sounds great. But who are you miss?
 Eso suena genial. Pero, ¿quién eres, señorita?
-Mmmmph~
-Mmmmmm~
+
 (SPEAKER giggles)|Hehe... We will have so much fun~
 (EL SPEAKER se ríe)|Jeje... Nos divertiremos mucho~
 (...)


### PR DESCRIPTION
I apologize for not being thorough enough and not considering that there might still be some minor "surprises" under certain circumstances. Therefore, before merging other translation files, I would like to ask you to merge this PR first. This is because once the translation files are merged, Github Action will start running, which could potentially cause some minor issues. Of course, these issues are not serious and will only affect a very small portion of the translation entries.

#### 1. format-translation-script.py
- Fixed the issue where annotations could be accidentally treated as translations.
- Repeated translations now will also be considered untranslated

#### 2. Github Action (format-translation.yml)
Remove an undeserved trigger condition

#### 3. About translation and revision

These translation formats have some surprising effects: (

When the coincidence in the original text is the translation of a word, it may lead to the mistranslation of the coincidental word into another word after formatting. This may lead to some chain reactions.

As follows, the translation of "Restart required!" "In the original text is also coincidentally" need to restart! " After formatting, the first "Restart required!" "In the original text is correctly translated into" need to restart! " , but the second original "needs to be restarted!"! "Will be incorrectly translated as" Domit "in the translation (this is a connected text)

There is no good solution to this problem, because it is impossible to absolutely judge which is the original text and which is the translation. Unless the matching logic is reconstructed to bind KEY instead of text when translating, it can also solve the translation problem of the same text for items with different ids. I don't think it's worth doing so in a short time. It's easy to affect the existing stability if the change is too big.

Fortunately, there are not many cases of this problem. I manually fixed the potentially problematic text that was found, and this is the best workaround for now.


csv file
```
RestartNeededEN,"Restart required!"
RestartNeededCN,"需要重启！"
```

File before formatting
```
Restart required!
需要重启！
Domit
支配者
```

File after formatting
```
Restart required!
需要重启！
需要重启！
Domit
### 재시작 필요！
### Restart please!
### ¡Reinicio!
### Rechargement requis!
```