### PR TITLE
Fix hotbar hotkey "hang".

### DIFF
--- a/Game/src/base/KinkyDungeonGame.ts
+++ b/Game/src/base/KinkyDungeonGame.ts
@@ -4346,8 +4346,8 @@ function KinkyDungeonGameKeyDown() {
 	} else if (KinkyDungeonKeySpellConfig.includes(KinkyDungeonKeybindingCurrentKey)) {
 		if (KinkyDungeonState == "Game") {
 			let index = 1 + KinkyDungeonKeySpellConfig.indexOf(KinkyDungeonKeybindingCurrentKey);
-			if (localStorage.getItem('KinkyDungeonSpellsChoice' + KinkyDungeonSpellsConfig)) {
-				KinkyDungeonSpellsConfig = index + "";
+			if (localStorage.getItem('KinkyDungeonSpellsChoice' + String (index))) {
+				KinkyDungeonSpellsConfig = String (index);
 				KinkyDungeonLoadSpellsConfig();
 			}
 		}

--- a/Game/src/magic/KinkyDungeonMagic.ts
+++ b/Game/src/magic/KinkyDungeonMagic.ts
@@ -2305,7 +2305,7 @@ function KinkyDungeonLoadSpellsConfig() {
 	if (spellsChoice) {
 		//KinkyDungeonSpellChoices = [];
 		KDClearChoices();
-		let list = JSON.parse(spellsChoice);
+		let list: string[] = JSON.parse(spellsChoice);
 		for (let spell of list) {
 			if (KDHasSpell(spell)) {
 				KinkyDungeonSpellChoices.push(KinkyDungeonSpells.findIndex((sp) => {
@@ -2424,7 +2424,7 @@ function KDDrawHotbar(xLoc: number, _yLoc: number, _name: string, _fn: (I: numbe
 		KinkyDungeonLoadSpellsConfig();
 		return true;
 	}, true, xLoc + 450, 640, w - 25 - h, 54,
-	localStorage.getItem('KinkyDungeonSpellsChoice' + 2) ? TextGet("KinkyDungeonLoadConfig") + "3" : "x", KinkyDungeonSpellsConfig == "3" ? "#ffffff" : "#888888", "");
+	localStorage.getItem('KinkyDungeonSpellsChoice' + 3) ? TextGet("KinkyDungeonLoadConfig") + "3" : "x", KinkyDungeonSpellsConfig == "3" ? "#ffffff" : "#888888", "");
 
 	DrawButtonKDEx("KDSaveSpellsConfig1", (_bdata) => {
 		KinkyDungeonSpellsConfig = "1";


### PR DESCRIPTION
The hotbar is loaded from localStorage from the storage keys `KinkyDungeonSpellsChoice[123]`.  However, if these localStorage keys don't exist, then the hotkeys to switch directly to them stop working. This was because the test for storage key existence was made for the previous index value, not the new candidate.  The invalid new value would be stored in `KinkyDungeonSpellsConfig`, and the localStorage test would fail forevermore after that.

Test for existence of the new storage key value.  If present, assign KinkyDungeonSpellsConfig to the new index and update the hotbar.  If the storage key does not exist, `KinkyDungeonSpellsConfig` and the live hotbar will remain unchanged.

Also: Fix a wrong index when configuring the hotkey buttons.

Also also: Apply the correct type to `list` when loading the spells config (bearing in mind `JSON.parse()` does no schema validation).