### PR TITLE
Promisify Mod Loading and Translations

### DIFF
--- a/Scripts/Translation.ts
+++ b/Scripts/Translation.ts
@@ -295,3 +295,67 @@ function GetUserPreferredLanguage() {
 	return "";
 
 }
+/**
+ * Loads an array of texts loaded from a .csv file
+ * @param text1 - Primary array to load - this will probably be English
+ * @param text2 - Secondary array to load - this is probably a translation - This part might not be working? 
+ */
+function KDLoadTranslations(text1: string, text2: string = null) {
+	let parsedkeys = {};
+	let parsedkeystranslation = {};
+	const text1array = text1.replace(/\r\n?/g, '\n').trim().split('\n');
+	text1array.forEach((line: string) => {
+		try {
+			let keyloc = line.indexOf(",");
+			const textkey = line.slice(0,keyloc);
+			let val = line.slice(keyloc+1);
+			// Remove quotes if the value string has commas in it. 
+			if ((val.startsWith('"') && (val.endsWith('"'))) || ((val.startsWith("'")) && (val.endsWith("'")))) {
+				val = val.slice(1,-1);
+			}
+			if (textkey === null || val === undefined) {
+				console.log("Error while parsing line: " + line);
+			}
+			else {
+				parsedkeys[textkey] = val;
+			}
+		}
+		catch (err) {
+			console.log(err);
+		}
+	})
+	if (text2 != null) {
+		const text2array = text2.replace(/\r\n?/g, '\n').trim().split('\n');
+		text2array.forEach((line: string) => {
+			try {
+				let keyloc = line.indexOf(",");
+				const textkey = line.slice(0,keyloc);
+				let val = line.slice(keyloc+1);
+				// Remove quotes if the value string has commas in it. 
+				if ((val.startsWith('"') && (val.endsWith('"'))) || ((val.startsWith("'")) && (val.endsWith("'")))) {
+					val = val.slice(1,-1);
+				}
+				if (textkey === null || val === undefined) {
+					console.log("Error while parsing line: " + line);
+				}
+				else {
+					parsedkeystranslation[textkey] = val;
+				}
+			}
+			catch (err) {
+				console.log(err);
+			}
+		})
+	}
+	const keys = Object.keys(parsedkeys)
+	console.log(parsedkeys);
+	console.log(parsedkeystranslation);
+	keys.forEach((key: string) => {
+		if (parsedkeystranslation[key] != undefined) {
+			addTextKey(key, (parsedkeystranslation[key].slice('\r')));
+		}
+		else {
+			addTextKey(key, (parsedkeys[key].slice('\r')));
+		}
+	})
+}


### PR DESCRIPTION
Implements translations into KD Mod Config menus and sets up a promise chain based on KDModLoadOrder. This ensures each mod's .ks and .js files are loaded completely after the Reader's onload event before proceeding, as that event fires asynchronously.

Mods can also now supply translation files in a two column csv file of a similar format to translations already implemented in game. A .csv file ending in EN.csv will be used first, then if there is a different language active, it will try to find a .csv file ending in that language code.

See here for a .csv file that is loading from my mod in my current testing setup: https://discord.com/channels/938203644023685181/1252003158012465282/1290484613751246848 