### PR TITLE
Update to Class Mode Selection

### DIFF
--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -2455,12 +2455,12 @@ function KinkyDungeonRun() {
 				localStorage.setItem("KinkyDungeonClassMode", "" + KinkyDungeonClassMode);
 				return true;
 			}, (!KDClassReqs[Object.keys(KDClassStart)[i]]) || KDClassReqs[Object.keys(KDClassStart)[i]](),
-			buttonsstart + (buttonspad + buttonswidth) * X, 190 + Y*(buttonsheight + buttonsypad), buttonswidth, buttonsheight, TextGet("KinkyDungeonClassMode" + i),
+			buttonsstart + (buttonspad + buttonswidth) * X, 190 + Y*(buttonsheight + buttonsypad), buttonswidth, buttonsheight, TextGet("KinkyDungeonClassMode" + Object.keys(KDClassStart)[i]),
 				((!KDClassReqs[Object.keys(KDClassStart)[i]]) || KDClassReqs[Object.keys(KDClassStart)[i]]()) ?
 				(KinkyDungeonClassMode == Object.keys(KDClassStart)[i] ? "#ffffff" : "#888888")
 				: "#ff5555", "", undefined, undefined, true, KDButtonColor);
 			if (MouseIn(buttonsstart + (buttonspad + buttonswidth) * X, 190 + Y*(buttonsheight + buttonsypad), buttonswidth, buttonsheight)) {
-				DrawTextFitKD(TextGet("KinkyDungeonClassModeDesc" + i), 1250, 120, 1000, "#ffffff", KDTextGray0);
+				DrawTextFitKD(TextGet("KinkyDungeonClassModeDesc" + Object.keys(KDClassStart)[i]), 1250, 120, 1000, "#ffffff", KDTextGray0);
 			}
 		}
 

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -8056,16 +8056,16 @@ KinkyDungeonSexyPlugsFront,Allow Front Plugs
 KinkyDungeonSexyPlugs,Allow Rear Plugs
 KinkyDungeonSexyPiercings,Allow Piercings
 
-KinkyDungeonClassMode0,Fighter
-KinkyDungeonClassModeDesc0,"Start with 150 willpower and Iron Will, good at melee and blocking attacks."
-KinkyDungeonClassMode1,Rogue
-KinkyDungeonClassModeDesc1,"Start with 150 stamina and Sneaky, good at stealth and evasive gameplay."
-KinkyDungeonClassMode2,Wizard
-KinkyDungeonClassModeDesc2,"Start with 150 mana and Magical Sight, good at casting spells."
-KinkyDungeonClassMode3,Peasant
-KinkyDungeonClassModeDesc3,"Start with nothing to your name. For those who want a challenge."
-KinkyDungeonClassMode4,Trainee
-KinkyDungeonClassModeDesc4,"You are a mage, but haven't finished your formal 'training'. Requires Aroused mode."
+KinkyDungeonClassModeFighter,Fighter
+KinkyDungeonClassModeDescFighter,"Start with 150 willpower and Iron Will, good at melee and blocking attacks."
+KinkyDungeonClassModeRogue,Rogue
+KinkyDungeonClassModeDescRogue,"Start with 150 stamina and Sneaky, good at stealth and evasive gameplay."
+KinkyDungeonClassModeMage,Wizard
+KinkyDungeonClassModeDescMage,"Start with 150 mana and Magical Sight, good at casting spells."
+KinkyDungeonClassModePeasant,Peasant
+KinkyDungeonClassModeDescPeasant,"Start with nothing to your name. For those who want a challenge."
+KinkyDungeonClassModeTrainee,Trainee
+KinkyDungeonClassModeDescTrainee,"You are a mage, but haven't finished your formal 'training'. Requires Aroused mode."
 
 KDRandomMode,"Spell Choice:"
 


### PR DESCRIPTION
This changes the textkeys to use the class's internal name instead of a number. Allows for mods to add classes to the KDClassStart list and add their textkeys by name so they don't conflict with each other.

Also LF didn't fight me this time. 