### PR TITLE
Unidentified Wear Perk

### DIFF
--- a/Game/src/item/KinkyDungeonInventory.ts
+++ b/Game/src/item/KinkyDungeonInventory.ts
@@ -1088,7 +1088,7 @@ function KinkyDungeonDrawInventorySelected (
 	if (!item) return false;
 	let name = item.name;
 	let prefix = "KinkyDungeonInventoryItem";
-	let nameText = KDGetItemName(item.item);
+	let nameText = (KinkyDungeonStatsChoice.get("UnidentifiedWear") && (item.item.type == LooseRestraint)) ? ((item.item.name == KDRestraint(item.item).name) ? "" : "Enchanted ") + TextGet(`Restraint${KDRestraint(item.item).name}`) : KDGetItemName(item.item)
 	if (item.item.type == Restraint || item.item.type == LooseRestraint) {
 		prefix = "Restraint";
 	}
@@ -1097,8 +1097,8 @@ function KinkyDungeonDrawInventorySelected (
 	DrawTextFitKD(nameText, xOffset + canvasOffsetX_ui + 640*KinkyDungeonBookScale/3.35, canvasOffsetY_ui + 483*KinkyDungeonBookScale/5, 300, KDBookText, KDTextTan, undefined, undefined, 129);
 	//let wrapAmount = KDBigLanguages.includes(TranslationLanguage) ? 9 : 22;
 	let mult = KDGetFontMult();
-	let textSplit = KinkyDungeonWordWrap(TextGet(prefix + name + "Desc"), 12*mult, 26*mult).split('\n');
-	let textSplit2 = KinkyDungeonWordWrap(TextGet(prefix + name + "Desc2"), 12*mult, 28*mult).split('\n');
+	let textSplit = KinkyDungeonWordWrap((KinkyDungeonStatsChoice.get("UnidentifiedWear") && prefix == "Restraint") ? TextGet(`${prefix}${KDRestraint(item.item).name}Desc`) : TextGet(prefix + name + "Desc"), 12*mult, 26*mult).split('\n');
+	let textSplit2 = KinkyDungeonWordWrap((KinkyDungeonStatsChoice.get("UnidentifiedWear") && prefix == "Restraint") ? TextGet(`${prefix}${KDRestraint(item.item).name}Desc2`) : TextGet(prefix + name + "Desc2"), 12*mult, 28*mult).split('\n');
 
 	let data = {
 		extraLines: [],
@@ -1310,10 +1310,11 @@ function KinkyDungeonDrawInventorySelected (
 	for (let N = 0; N < textSplit2.length; N++) {
 		DrawTextFitKD(textSplit2[N],
 			xOffset + canvasOffsetX_ui + 640*KinkyDungeonBookScale*(1-1.0/3.35), canvasOffsetY_ui + 483*KinkyDungeonBookScale/5 + i * 32, 640*KinkyDungeonBookScale/2.5, KDBookText, KDTextTan, 24, undefined, 130); i++;}
-	for (let N = 0; N < data.extraLines.length; N++) {
-		DrawTextFitKD(data.extraLines[N],
-			xOffset + canvasOffsetX_ui + 640*KinkyDungeonBookScale*(1-1.0/3.35), canvasOffsetY_ui + 483*KinkyDungeonBookScale/5 + i * 32, 640*KinkyDungeonBookScale/2.5, data.extraLineColor[N], data.extraLineColorBG[N], 24, undefined, 130); i++;}
-
+	if ((KinkyDungeonStatsChoice.get("UnidentifiedWear") && item.item.type == Restraint) || (!KinkyDungeonStatsChoice.get("UnidentifiedWear"))) {
+		for (let N = 0; N < data.extraLines.length; N++) {
+			DrawTextFitKD(data.extraLines[N],
+				xOffset + canvasOffsetX_ui + 640*KinkyDungeonBookScale*(1-1.0/3.35), canvasOffsetY_ui + 483*KinkyDungeonBookScale/5 + i * 32, 640*KinkyDungeonBookScale/2.5, data.extraLineColor[N], data.extraLineColorBG[N], 24, undefined, 130); i++;}	
+	}
 	i = 0;
 
 	return true;

--- a/Game/src/player/KinkyDungeonPerks.ts
+++ b/Game/src/player/KinkyDungeonPerks.ts
@@ -295,6 +295,7 @@ let KinkyDungeonStatsPresets: Record<string, KDPerk> = {
 	"KeepOutfit":  {category: "Restraints", id: "KeepOutfit", cost: 0},
 	"CursedLocks": {category: "Restraints", id: "CursedLocks", cost: -1.5},
 	"FranticStruggle": {category: "Restraints", id: "FranticStruggle", cost: 1.5},
+	"UnidentifiedWear": {category: "Restraints", id: "UnidentifiedWear", cost: -1.5},
 	"Unchained": {category: "Kinky", id: 26, cost: 2.5, block: ["Damsel"]},
 	"Damsel": {category: "Kinky", id: 27, cost: -1, block: ["Unchained"]},
 	"Artist": {category: "Kinky", id: 28, cost: 2.5, block: ["Bunny"]},

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -709,6 +709,9 @@ KinkyDungeonStatDescArousingMagic,"Your magic is powered by otherworldly distrac
 KinkyDungeonStatClearheaded,"Clearheaded"
 KinkyDungeonStatDescClearheaded,"Magic puts you in a clear state of mind. Casting spells successfully reduces your distraction."
 
+KinkyDungeonStatUnidentifiedWear,"Unidentified Wear"
+KinkyDungeonStatDescUnidentifiedWear,"Enchantments on restraints and armor are hidden while unequipped."
+
 
 KinkyDungeonCopyPerks,Copy (clipboard)
 KinkyDungeonPastePerks,Paste (clipboard)


### PR DESCRIPTION
Adds a negative perk that hides the enchanted stats on wearable gear unless the player is currently wearing it.