### PR TITLE
Debug Mode Additions

### DIFF
--- a/Game/src/base/KinkyDungeonDraw.ts
+++ b/Game/src/base/KinkyDungeonDraw.ts
@@ -1985,7 +1985,42 @@ function KinkyDungeonDrawGame() {
 					DrawButtonVis(1100, 300, 300, 64, "Teleport to stairs", "#ffffff", "");
 					DrawButtonVis(1500, 320, 300, 64, "Get save code", "#ffffff", "");
 					DrawButtonVis(1100, 370, 300, 64, "Enter parole mode", "#ffffff", "");
-
+					DrawButtonKDEx("debugDefeat", (_bdata) => {
+                        console.log("Defeat Enemy...");
+                        KinkyDungeonTargetingSpell = KinkyDungeonHandleSpellCast({ name: "debugDefeat", 
+                            tags: ["metal", "binding", "utility"], 
+                            sfx: "MagicSlash", 
+                            school: "Conjure", 
+                            manacost: 0, 
+                            components: [], 
+                            mustTarget: true, 
+                            level: 1,
+                            type: "special", special: "debugDefeat",
+                            onhit: "", time: 1, power: 3.5, range: 15, size: 1, damage: "" }
+                        )
+                        KinkyDungeonTargetingSpellItem = null;
+                        KinkyDungeonTargetingSpellWeapon = null;
+                        KinkyDungeonDrawState = "Game"
+                        return true;
+                    }, true, 600, 96, 145, 48, "Defeat", "#ffffff", "");
+                    DrawButtonKDEx("debugBind", (_bdata) => {
+                        console.log("Bind Enemy...");
+                        KinkyDungeonTargetingSpell = KinkyDungeonHandleSpellCast({ name: "debugBind", 
+                            tags: ["metal", "binding", "utility"], 
+                            sfx: "MagicSlash", 
+                            school: "Conjure", 
+                            manacost: 0, 
+                            components: [], 
+                            mustTarget: true, 
+                            level: 1,
+                            type: "special", special: "debugBind",
+                            onhit: "", time: 1, power: 3.5, range: 15, size: 1, damage: "" }
+                        )
+                        KinkyDungeonTargetingSpellItem = null;
+                        KinkyDungeonTargetingSpellWeapon = null;
+                        KinkyDungeonDrawState = "Game"
+                        return true;
+                    }, true, 755, 96, 145, 48, "Bind", "#ffffff", "");
 					DrawButtonKDEx("debugAddKey", (_bdata) => {
 						KDAddConsumable("Pick", 10);
 						KDAddConsumable("RedKey", 10);
@@ -2026,22 +2061,39 @@ function KinkyDungeonDrawGame() {
 						KDTickSpecialStats();
 						return true;
 					}, true, 600, 640, 300, 64, "Increment Floor", "#ffffff", "");
-					DrawButtonKDEx("+maxAP", (_bdata) => {
-						KDGameData.StatMaxBonus.AP += 10;
-						return true;
-					}, true, 600, 720, 150, 64, "+Max DP", "#ffaaaa", "");
-					DrawButtonKDEx("+maxMP", (_bdata) => {
-						KDGameData.StatMaxBonus.MP += 10;
-						return true;
-					}, true, 750, 720, 150, 64, "+Max MP", "#0088ff", "");
-					DrawButtonKDEx("+maxSP", (_bdata) => {
-						KDGameData.StatMaxBonus.SP += 10;
-						return true;
-					}, true, 600, 800, 150, 64, "+Max SP", "#44ff00", "");
-					DrawButtonKDEx("+maxWP", (_bdata) => {
-						KDGameData.StatMaxBonus.WP += 10;
-						return true;
-					}, true, 750, 800, 150, 64, "+Max WP", "#ff5555", "");
+					DrawButtonKDEx("RestSP", (_bdata) => {
+                        KDChangeStamina("","","",100)
+                        return true;
+                    }, true, 600, 720, 145, 48, "Rest SP", "#ffffff", "")
+                    DrawButtonKDEx("+maxSP", (_bdata) => {
+                        KDGameData.StatMaxBonus.SP += 10;
+                        return true;
+                    }, true, 755, 720, 145, 48, "+Max SP", "#44ff00", "")
+                    DrawButtonKDEx("RestMP", (_bdata) => {
+                        KDChangeMana("","","",100)
+                        return true;
+                    }, true, 600, 780, 145, 48, "Rest MP", "#ffffff", "")
+                    DrawButtonKDEx("+maxMP", (_bdata) => {
+                        KDGameData.StatMaxBonus.MP += 10;
+                        return true;
+                    }, true, 755, 780, 145, 48, "+Max MP", "#0088ff", "")
+                    DrawButtonKDEx("RestWP", (_bdata) => {
+                        KDChangeWill("","","",100)
+                        return true;
+                    }, true, 600, 840, 145, 48, "Rest WP", "#ffffff", "")
+                    DrawButtonKDEx("+maxWP", (_bdata) => {
+                        KDGameData.StatMaxBonus.WP += 10;
+                        return true;
+                    }, true, 755, 840, 145, 48, "+Max WP", "#ff5555", "")
+                    DrawButtonKDEx("RestDP", (_bdata) => {
+                        KDChangeDistraction("","","",-100)
+                        KDChangeDesire("","","",-100,true)
+                        return true;
+                    }, true, 600, 900, 145, 48, "Rest DP", "#ffffff", "")
+                    DrawButtonKDEx("+maxDP", (_bdata) => {
+                        KDGameData.StatMaxBonus.DP += 10;
+                        return true;
+                    }, true, 755, 900, 145, 48, "+Max DP", "#ffaaaa", "")
 
 
 

--- a/Game/src/faction/KinkyDungeonReputation.ts
+++ b/Game/src/faction/KinkyDungeonReputation.ts
@@ -352,6 +352,17 @@ function KinkyDungeonDrawReputation() {
 			if (suff) {
 				DrawTextFitKD(suff, canvasOffsetX_ui + xOffset + 275 + XX + 240, yPad + canvasOffsetY_ui + spacing * i, 100, "white", "black", undefined, "left");
 			}
+			// Draw between the % and bar and suffix if debug mode is active. 
+            if (KDDebugMode) {
+                DrawButtonKDEx("minusrep" + rep, (_bdata) => {
+                    KinkyDungeonChangeRep(rep, -5)
+                    return true;
+                }, true, canvasOffsetX_ui + xOffset + 275 + XX - 30, yPad + canvasOffsetY_ui + spacing * i - 15, 30, 30, "-", "#ffffff");
+                DrawButtonKDEx("plusrep" + rep, (_bdata) => {
+                    KinkyDungeonChangeRep(rep, 5)
+                    return true;
+                }, true, canvasOffsetX_ui + xOffset + 275 + XX + 203, yPad + canvasOffsetY_ui + spacing * i - 15, 30, 30, "+", "#ffffff");
+            }
 			DrawProgressBar(canvasOffsetX_ui + xOffset + 275 + XX, yPad + canvasOffsetY_ui + spacing * i - spacing/4, 200, spacing/2, 50 +
 				(rep == "Prisoner" ? KDGetEffSecurityLevel(undefined, true) :
 				value), color, KDTextGray2);
@@ -560,6 +571,17 @@ function KinkyDungeonDrawFactionRep() {
 			if (suff) {
 				DrawTextFitKD(suff, canvasOffsetX_ui + xOffset + barSpacing + XX + 250, yPad + canvasOffsetY_ui + spacing * i, 100, "white", "black", undefined, "left");
 			}
+			// Draw between the % and bar and suffix if debug mode is active. 
+            if (KDDebugMode) {
+                DrawButtonKDEx("minusfactionrep" + rep, (_bdata) => {
+                    KinkyDungeonChangeFactionRep(rep, -0.1)
+                    return true;
+                }, true, canvasOffsetX_ui + xOffset + barSpacing + XX - 30, yPad + canvasOffsetY_ui + spacing * i - 15, 30, 30, "-", "#ffffff");
+                DrawButtonKDEx("plusfactionrep" + rep, (_bdata) => {
+                    KinkyDungeonChangeFactionRep(rep, 0.1)
+                    return true;
+                }, true, canvasOffsetX_ui + xOffset + barSpacing + XX + 203, yPad + canvasOffsetY_ui + spacing * i - 15, 30, 30, "+", "#ffffff");
+            }
 			DrawProgressBar(canvasOffsetX_ui + xOffset + barSpacing + XX, yPad + canvasOffsetY_ui + spacing * i - spacing/4, 200, spacing/2, 50 + value * 50, color, KDTextGray2);
 
 			DrawTextKD(" " + (Math.round(value * 50)+50) + " ", canvasOffsetX_ui + xOffset + barSpacing + XX + 100,  1+yPad + canvasOffsetY_ui + spacing * i, "white", "black");

--- a/Game/src/magic/KinkyDungeonMagicCode.ts
+++ b/Game/src/magic/KinkyDungeonMagicCode.ts
@@ -2205,6 +2205,48 @@ let KinkyDungeonSpellSpecials: Record<string, KDSpellSpecialCode> = {
 			if (_miscast) return "Miscast";
 			return KinkyDungeonActivateWeaponSpell(true) ? "Cast" : "Fail";
 		}
+	},
+	"debugBind": (spell, _data, targetX, targetY, tX, tY, entity, _enemy, moveDirection, bullet, miscast, faction, cast, selfCast) => {
+		try {
+			let e = KDNearbyEnemies(tX, tY, 1)
+			let debugDamage = {
+				type: "chain",
+				damage: 999.9,
+				time: 0,
+				bind: 1000,
+				distract: 0,
+			}
+			if (e) {
+				console.log(e);
+				if (e[0]) {
+					KinkyDungeonDamageEnemy(e[0], debugDamage, false, true, undefined, undefined, KinkyDungeonPlayerEntity, 0.1);
+				}
+			} 
+		}
+		catch (err) {
+			console.log(err);
+		}
+	},
+	"debugDefeat": (spell, _data, targetX, targetY, tX, tY, entity, _enemy, moveDirection, bullet, miscast, faction, cast, selfCast) => {
+		try {
+			let e = KDNearbyEnemies(tX, tY, 1)
+			let debugDamage = {
+				type: "pain",
+				damage: 999.9,
+				time: 0,
+				bind: 0,
+				distract: 0,
+			}
+			if (e) {
+				console.log(e);
+				if (e[0]) {
+					KinkyDungeonDamageEnemy(e[0], debugDamage, false, true, undefined, undefined, KinkyDungeonPlayerEntity, 0.1);
+				}
+			} 
+		}
+		catch (err) {
+			console.log(err);
+		}
 	}
 };
 

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -26386,3 +26386,8 @@ KDUnknown,???
 KDSaveBusy,Wait for current save to finish...
 
 KDSaveBusyMenu,"Please wait for save to finish..."
+
+KinkyDungeonSpelldebugDefeat,"Debug Defeat"
+KinkyDungeonSpellCastdebugDefeat,"You cast devastating ASCII glyphs!"
+KinkyDungeonSpelldebugBind,"Debug Bind"
+KinkyDungeonSpellCastdebugBind,"You cast bondage ASCII glyphs!"


### PR DESCRIPTION
This adds the following to Debug Mode:
- A button to restore SP, MP, WP or DP to their "natural" state. DP and desire are reduced, but the others are restored to 100% using the KDChange___ functions. Additionally, these are rearranged to reflect the order displayed in-game.
- Buttons on each rep in the rep screen to add/remove 5% rep with them. Uses the appropriate rep change function.
- Buttons to deal 9999 pain damage or 9999 binding chain damage to a target using a special spell cast.