### PR TITLE
Extra Warning Tiles

### DIFF
--- a/Game/src/base/KinkyDungeonGame.ts
+++ b/Game/src/base/KinkyDungeonGame.ts
@@ -5771,7 +5771,7 @@ function KinkyDungeonAdvanceTime(delta: number, NoUpdate?: boolean, NoMsgTick?: 
 	KinkyDungeonUpdateBullets(delta); //console.log("Bullets Check " + (performance.now() - now));
 	KinkyDungeonUpdateBulletsCollisions(delta, true); //"catchup" phase for explosions!
 
-
+	KinkyDungeonParseExtraWarningTiles() // Add custom warning indicators!
 
 	KDUpdateEffectTiles(delta);
 	KinkyDungeonUpdateTileEffects(delta);

--- a/Game/src/fight/KinkyDungeonFight.ts
+++ b/Game/src/fight/KinkyDungeonFight.ts
@@ -1950,6 +1950,39 @@ function KinkyDungeonUpdateBulletVisuals(delta: number) {
 		}
 }
 
+let KinkyDungeonExtraWarningTiles = [];
+
+function KinkyDungeonCreateWarningTile(x: number, y: number, color: string = "#ffffff", duration: number = 1, delay: number = 0, x_orig?: number, y_orig?: number) {
+	KinkyDungeonExtraWarningTiles.push({
+		duration: duration,
+		delay: delay,
+		warning: {
+			color: color,
+			scale: 1,
+			x: x,
+			x_orig: (x_orig) ? x_orig : x,
+			y: y,
+			y_orig: (y_orig) ? y_orig : y
+		}
+	})
+}
+
+function KinkyDungeonParseExtraWarningTiles() {
+	for (let i = 0; i < KinkyDungeonExtraWarningTiles.length; i++) {
+		if (KinkyDungeonExtraWarningTiles[i].delay > 0) {
+			KinkyDungeonExtraWarningTiles[i].delay--;
+		}
+		else {
+			KDBulletWarnings.push(Object.assign({}, KinkyDungeonExtraWarningTiles[i].warning));
+		}
+		KinkyDungeonExtraWarningTiles[i].duration--;
+		if (KinkyDungeonExtraWarningTiles[i].duration <= 0) {
+			KinkyDungeonExtraWarningTiles.splice(i, 1);
+			i--;
+		}
+	}
+}
+
 let KinkyDungeonCurrentTick = 0;
 
 function KinkyDungeonUpdateBulletsCollisions(delta: number, Catchup?: boolean) {


### PR DESCRIPTION
This adds a helper function to add a bullet warning indicator that is separate from an enemy intent or bullet trajectory. It supports a duration and delay property based on ticks (or well, each time the function is called in the AdvanceTime function), with defaults that will simply place a white indicator at the x,y location for 1 tick.