### PR TITLE
Bugfix: KinkyDungeonRemoveRestraint() now restores offhand weapon.

### DIFF
--- a/Game/src/restraint/KinkyDungeonRestraints.ts
+++ b/Game/src/restraint/KinkyDungeonRestraints.ts
@@ -4707,6 +4707,13 @@ function KinkyDungeonRemoveRestraint(Group: string, Keep?: boolean, Add?: boolea
 			if (KinkyDungeonPlayerWeapon != KinkyDungeonPlayerWeaponLastEquipped && KinkyDungeonInventoryGet(KinkyDungeonPlayerWeaponLastEquipped)) {
 				KDSetWeapon(KinkyDungeonPlayerWeaponLastEquipped);
 			}
+			// Reequip offhand if able
+			if (KDGameData.OffhandOld && !KDGameData.Offhand
+				&& KinkyDungeonInventoryGetWeapon(KDGameData.OffhandOld)
+				&& KinkyDungeonCanUseWeapon(false, undefined, KDWeapon(KinkyDungeonInventoryGetWeapon(KDGameData.OffhandOld)))
+				&& KDCanOffhand(KinkyDungeonInventoryGetWeapon(KDGameData.OffhandOld))) {
+				KDGameData.Offhand = KDGameData.OffhandOld;
+			}
 			return rem;
 		}
 	}


### PR DESCRIPTION
KinkyDungeonRemoveRestraint() currently restores the player's main-hand weapon after escaping restraints.  However, the player's offhand weapon will remain grayed out, even if it is a valid offhand weapon to equip.

This bugfix allows this function to also restore the player's off-hand weapon.

Made with code borrowed from KinkyDungeonInput.ts