### PR TITLE
Refactor sleep

### DIFF
--- a/Game/src/base/KinkyDungeonInput.ts
+++ b/Game/src/base/KinkyDungeonInput.ts
@@ -37,7 +37,9 @@ function KDProcessInput(type: string, data: any): string {
 			if (data.sleep == 10 && (KDGameData.PrisonerState == 'jail' || KDGameData.PrisonerState == 'parole') && KinkyDungeonPlayerInCell()) {
 				KDKickEnemies(KinkyDungeonNearestJailPoint(KinkyDungeonPlayerEntity.x, KinkyDungeonPlayerEntity.y), false, MiniGameKinkyDungeonLevel, true);
 			}
-			if (data.sleep && KinkyDungeonStatWill < KinkyDungeonStatWillMax * KDGetSleepWillFraction()) KDChangeWill("player","wait", "tick", KinkyDungeonStatWillMax/KDMaxStatStart * KDSleepRegenWill, false);
+			if(data.sleep) {
+				KDSleepTick();
+			}
 			KinkyDungeonAdvanceTime(data.delta, data.NoUpdate, data.NoMsgTick);
 			break;
 		case "tryCastSpell": {

--- a/Game/src/dialogue/KinkyDungeonDialogueList.ts
+++ b/Game/src/dialogue/KinkyDungeonDialogueList.ts
@@ -1143,13 +1143,7 @@ let KDDialogue: Record<string, KinkyDialogue> = {
 						}
 					}
 
-					KinkyDungeonSetFlag("slept", -1);
-					if (KinkyDungeonPlayerInCell(true) && KDGameData.PrisonerState == 'jail') {
-						KinkyDungeonChangeRep("Ghost", KinkyDungeonIsArmsBound() ? 5 : 2);
-					}
-					//KinkyDungeonChangeWill(KinkyDungeonStatWillMax * KDSleepBedPercentage);
-					KDGameData.SleepTurns = KinkyDungeonSleepTurnsMax;
-					KDChangeMana("player","sleep", "tick", KinkyDungeonStatManaMax, false, 0, false, true);
+					KDSleep();
 					return false;
 				},
 				options: {
@@ -1157,6 +1151,12 @@ let KDDialogue: Record<string, KinkyDialogue> = {
 						playertext: "Leave", response: "Default",
 						exitDialogue: true,
 					},
+				},
+				greyoutFunction: (_gagged, _player) => {
+					return KDCanSleep();
+				},
+				greyoutCustomTooltip: (_gagged, _player) => {
+					return KDCanSleepTooltip();
 				}
 			},
 			"Leave": {

--- a/Game/src/map/KinkyDungeonObject.ts
+++ b/Game/src/map/KinkyDungeonObject.ts
@@ -128,13 +128,13 @@ let KDObjectInteract: Record<string, (x: number, y: number, dist?: number) => bo
  */
 let KDTileInteract: Record<string, (x: number, y: number, dist?: number) => boolean> = {
 	'B': (x, y, dist) => {
-		if (dist != undefined ? dist : KDistChebyshev(x - KDPlayer().x, y - KDPlayer().y) < 1.5)
-			if (!KinkyDungeonFlags.get("slept") && !KinkyDungeonFlags.get("nobed") && KinkyDungeonStatWill < KinkyDungeonStatWillMax * 0.49) {
-				KDGameData.InteractTargetX = x;
-				KDGameData.InteractTargetY = y;
-				KDStartDialog("Bed", "", true);
-				return true;
-			}
+		// "nobed" flag is to prevent interacting with the bed during combat, because it's annoying if it keeps popping up every turn
+		if (dist != undefined ? dist : KDistChebyshev(x - KDPlayer().x, y - KDPlayer().y) < 1.5 && !KinkyDungeonFlags.get("nobed")) {
+			KDGameData.InteractTargetX = x;
+			KDGameData.InteractTargetY = y;
+			KDStartDialog("Bed", "", true);
+			return true;
+		}
 		return false;
 	},
 	'c': (x, y, dist) => {

--- a/Game/src/map/KinkyDungeonTilesList.ts
+++ b/Game/src/map/KinkyDungeonTilesList.ts
@@ -414,7 +414,7 @@ let KDTileUpdateFunctions: Record<string, (delta: number) => boolean> = {
  */
 let KDMoveObjectFunctions: Record<string, (moveX: number, moveY: number) => boolean> = {
 	'B': (_moveX, _moveY) => {
-		/*if (!KinkyDungeonFlags.get("slept") && !KinkyDungeonFlags.get("nobed") && KinkyDungeonStatWill < KinkyDungeonStatWillMax * 0.49) {
+		/*if (KDCanSleep()) {
 			KDGameData.InteractTargetX = moveX;
 			KDGameData.InteractTargetY = moveY;
 			KDStartDialog("Bed", "", true);

--- a/Game/src/player/KinkyDungeonStats.ts
+++ b/Game/src/player/KinkyDungeonStats.ts
@@ -6,18 +6,73 @@ let KinkyDungeonPlayerEntity: any = {id: -1, Enemy: undefined, hp: 10, x: 0, y:0
 let KDBaseBalanceDmgLevel = 5; // Decides how much heels affect balance loss from attacks. higher = less loss
 let KDShadowThreshold = 1.5;
 
-let KDSleepWillFraction = 0.5;
-let KDSleepWillFractionJail = 0.5;
+/** Sleep */
+let KDSleepWillFraction = 0.5;     // Will restored to this percentage when sleeping
+let KDSleepWillFractionJail = 0.5; // Will restored to this percentage when sleeping in Jail
+
+/**
+ * @returns health to regenerate to during sleep
+ */
+function KDGetSleepWillRegenHealthTo() {
+	return Math.ceil(KinkyDungeonStatWillMax * (KDGameData.PrisonerState == 'jail' ? KDSleepWillFractionJail : KDSleepWillFraction));
+}
+
+/**
+ * Can the player sleep in a bed?
+ */
+function KDCanSleep() {
+	let willUnderTreshold = KinkyDungeonStatWill < KDGetSleepWillRegenHealthTo();
+	let jailedOrNotSleptOnLevel = KinkyDungeonPlayerInCell() || !KinkyDungeonFlags.get('slept');
+	return willUnderTreshold && jailedOrNotSleptOnLevel;
+}
+
+/**
+ * @returns Tooltip why player is unable to sleep at bed
+ */
+function KDCanSleepTooltip() {
+	if(KinkyDungeonFlags.get('slept') && !KinkyDungeonPlayerInCell()) {
+		return "KDBedSleptLevel";
+	}
+	if(KinkyDungeonStatWill >= KDGetSleepWillRegenHealthTo()) {
+		return "KDBedWillNotLow";
+	}
+
+	console.error("KDCanSleepTooltip should not reach this point")
+	return "KDBedWillNotLow";
+}
+
+/**
+ * Set state required for player to sleep
+ */
+function KDSleep() {
+	KinkyDungeonSetFlag("slept", -1); // prevent sleeping again on this floor
+	if (KinkyDungeonPlayerInCell(true) && KDGameData.PrisonerState == 'jail') {
+		KinkyDungeonChangeRep("Ghost", KinkyDungeonIsArmsBound() ? 5 : 2);
+	}
+	KDGameData.SleepTurns = KinkyDungeonSleepTurnsMax; // sleep for this number of turns
+	KDChangeMana("player","sleep", "tick", KinkyDungeonStatManaMax, false, 0, false, true); // restore full mana instantly
+}
+
+/**
+ * Apply healing when player sleeps each turn
+ */
+function KDSleepTick() {
+	let regenToWill = KDGetSleepWillRegenHealthTo(); // regenerate to this health by the time sleep is done
+	let healingPerTurn = regenToWill / KinkyDungeonSleepTurnsMax; // regenerate this much will per turn
+	if (KinkyDungeonStatWill < regenToWill) {
+		let willBefore = KinkyDungeonStatWill;
+		KDChangeWill("player","wait", "tick", healingPerTurn, false);
+		// if we've overshot the target percentage then clamp to it
+		if(willBefore <= regenToWill && KinkyDungeonStatWill > regenToWill) {
+			KinkyDungeonStatWill = regenToWill;
+		}
+	}
+}
 
 let KDOrgAfterglowTime = 10;
 
 // Ratio of max shield to willpower max
 let KDShieldRatio = 1;
-
-function KDGetSleepWillFraction() {
-	if (KDGameData.PrisonerState == 'jail') return KDSleepWillFractionJail;
-	return KDSleepWillFraction;
-}
 
 // Distraction -- It lowers your stamina regen
 let KDMaxStat = 40; // Maximum any stat can get boosted to
@@ -26,8 +81,6 @@ let KDMaxStatStartPool = 40; // Start of stats
 
 let KDStamDamageThresh = 0.3;
 let KDStamDamageThreshBonus = 0.01;
-
-let KDSleepRegenWill = KDSleepWillFractionJail * KDMaxStatStart/40;
 
 let KinkyDungeonStatDistractionMax = KDMaxStatStart;
 let KDDistractionLowerPercMult = 0.1;

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -27598,3 +27598,6 @@ KDContextMenu_Truss,Tie Up
 KDContextMenu_TrussAttempt,Attempt to Tie
 KDContextMenu_TrussOOR,Move Closer to Tie
 KDContextMenu_Sprint,Sprint (AMNT)
+
+KDBedSleptLevel,(Already slept here)
+KDBedWillNotLow,(Will not low enough)


### PR DESCRIPTION
Refactor sleep code so it's more easily readable and moddable

Before you could only interact with the bed if you could sleep, which was very confusing for new players such as myself. Now you can always open the interaction with the bed but the sleep option will tell you if your will is not low enough or if you have already slept on the level (except when you are jailed).

Couldn't understand the usage for the "nobed" flag so I removed it. Did it do something?