### PR TITLE
Enhance Translation Sync Workflow: Merge Paratranz and GitHub PR Translations with Stability Focus

### DIFF
--- a/.github/scripts/format-translation-script.py
+++ b/.github/scripts/format-translation-script.py
@@ -101,6 +101,7 @@ original_csv_path = 'Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv'
 
 # Enable the translation files to be reordered
 translation_files = [
+    'Text_KinkyDungeon_CN.txt',
     'Text_KinkyDungeon_DE.txt',
     'Text_KinkyDungeon_KR.txt',
     'Text_KinkyDungeon_RU.txt',

--- a/.github/scripts/synchronous-translation-script.py
+++ b/.github/scripts/synchronous-translation-script.py
@@ -85,7 +85,7 @@ async def paratran_download():
 # Input file and output file paths
 input_csv = 'Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv'
 output_csv = 'Text_KinkyDungeon_Temp.csv'
-output_txt = 'Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt'
+output_txt = 'Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN_paratranz.txt'
 
 process_csv(input_csv, output_csv)
 print(f"save to {output_csv}")

--- a/.github/workflows/synchronous-translation.yml
+++ b/.github/workflows/synchronous-translation.yml
@@ -42,12 +42,11 @@ jobs:
           cat Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN_paratranz.txt >> Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt
           python .github/scripts/format-translation-script.py "Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt"
 
-
       - name: 📝 Commit changes
         id: check_changes
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "synchronous-translation-action"
-          git add . 
+          git add "Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt"
           git diff-index --quiet HEAD || git commit -m "Synchronous translation files"
           git push

--- a/.github/workflows/synchronous-translation.yml
+++ b/.github/workflows/synchronous-translation.yml
@@ -9,7 +9,7 @@ on:
     - cron: '0 0 * * *'
   push:
     branches:
-      - '5.4'
+      - 'newartwork'
     paths:
       - "Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv"
 
@@ -36,6 +36,12 @@ jobs:
         env:
           PARATRANZ_TOKEN: ${{ secrets.PARATRANZ_TOKEN }}
         run: python .github/scripts/synchronous-translation-script.py
+
+      - name: 📂 Merge translations
+        run: |
+          cat Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN_paratranz.txt >> Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt
+          python .github/scripts/format-translation-script.py "Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt"
+
 
       - name: 📝 Commit changes
         id: check_changes

--- a/.github/workflows/synchronous-translation.yml
+++ b/.github/workflows/synchronous-translation.yml
@@ -5,18 +5,17 @@ permissions:
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches:
       - 'newartwork'
     paths:
       - "Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv"
+      - "Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt"
 
 jobs:
   synchronous-translation:
     runs-on: ubuntu-latest
-    if: github.repository == 'Ada18980/KinkiestDungeon' && github.ref == 'refs/heads/newartwork'
+    if: github.repository == 'Ada18980/KinkiestDungeon'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/synchronous-translation.yml
+++ b/.github/workflows/synchronous-translation.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: 📂 Merge translations
         run: |
+          printf "\n\n" >> Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt
           cat Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN_paratranz.txt >> Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt
           python .github/scripts/format-translation-script.py "Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt"
 

--- a/.github/workflows/synchronous-translation.yml
+++ b/.github/workflows/synchronous-translation.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   synchronous-translation:
     runs-on: ubuntu-latest
-    if: github.repository == 'Ada18980/KinkiestDungeon'
+    if: github.repository == 'Ada18980/KinkiestDungeon' && github.ref == 'refs/heads/newartwork'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/synchronous-translation.yml
+++ b/.github/workflows/synchronous-translation.yml
@@ -38,8 +38,15 @@ jobs:
 
       - name: 📂 Merge translations
         run: |
-          printf "\n\n" >> Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt
-          cat Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN_paratranz.txt >> Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt
+          PATH_PARATRANZ="Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN_paratranz.txt"
+          PATH_ORIGIN="Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt"
+          PATH_TEMP=$(mktemp)
+          
+          cat "$PATH_PARATRANZ" > "$PATH_TEMP"
+          printf "\n\n" >> "$PATH_TEMP"
+          cat "$PATH_ORIGIN" >> "$PATH_TEMP"
+          mv "$PATH_TEMP" "$PATH_ORIGIN"
+          
           python .github/scripts/format-translation-script.py "Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt"
 
       - name: 📝 Commit changes

--- a/Screens/MiniGame/KinkyDungeon/README.md
+++ b/Screens/MiniGame/KinkyDungeon/README.md
@@ -1,0 +1,11 @@
+## Describe
+
+This is used to store game translation text. Select the corresponding `Text_KinkyDungeon_[lang].txt`, You can participate in the translation.
+
+For more information, please refer to [CONTRIBUTING.md](/.github/CONTRIBUTING.md).
+
+## Other
+
+### For Chinese(中国语翻译)
+
+可前往 [paratranz](https://paratranz.cn/projects/12190) 便捷参与KD汉化


### PR DESCRIPTION
**Change Summary:**

0. **Scope:**
   This PR only modifies the Chinese (CN) translation workflow components.

1. **Synchronous-Translation Action Update**
   - Revamped the `synchronous-translation` GitHub Action to **merge translations** from Paratranz with existing GitHub PR contributions.
   - Ensures translations submitted via GitHub PRs are preserved and not overwritten by Paratranz sync operations.

2. **[BREAKING CHANGE] Auto-Sync Trigger Adjustment**
   - Changed the trigger condition for the `auto-sync-translations` action to activate only on `newartwork` events.
   - **Reason:** The original implementation forcibly overwrote Paratranz cloud data with branch-specific CSV updates. This adjustment prioritizes syncing translations for stable releases only.

3. **Documentation Migration**
   - Migrated embedded translation guidelines to a dedicated `README` file under the translation directory.
   - Improves maintainability and visibility of translation workflow documentation.

4. **Translation Priority Policy**
   - Maintains the existing priority order:
     - Paratranz translations take precedence.
     - GitHub PR-contributed translations are retained as secondary sources.
