### PR TITLE
Refactor text module

### DIFF
--- a/Game/src/KinkyDungeonTests.ts
+++ b/Game/src/KinkyDungeonTests.ts
@@ -98,25 +98,6 @@ function KDTestjailer(iter: number) {
 	console.log(totals);
 }
 
-async function KDExportTranslationFile(cull: boolean) {
-	await sleep(1000);
-	let file = "";
-	let cache = cull ? {} : undefined;
-	if (cache) {
-		for (let i = 0; i + 1 < Object.values(TranslationCache)[0].length; i++) {
-			cache[Object.values(TranslationCache)[0][i + 1]] = Object.values(TranslationCache)[0][i];
-		}
-	}
-	for (let c of Object.values(TextScreenCache.cache)) {
-		if (!cache || !cache[c]) {
-			file = file + '\n' + c;
-			file = file + '\n ';
-		}
-
-	}
-	navigator.clipboard.writeText(file);
-}
-
 /**
  * Tests the variant item system
  * @param name

--- a/Game/src/base/KDModUtils.ts
+++ b/Game/src/base/KDModUtils.ts
@@ -8,30 +8,6 @@ enum KDModifierEnum {
 	consumable,
 };
 
-let PostTranslationRecord: [string, string][] = [];
-let MissingCSVTranslation: Record<string, string> = {};
-
-function addTextKey(Name: string, Text: string) {
-	let ct = 0;
-
-	for (let screen of TextAllScreenCache.entries()) {
-		if (screen[0].includes("KinkyDungeon")) {
-			if (!screen[1].cache[Name]) MissingCSVTranslation[Name] = Text;
-			screen[1].cache[Name] = screen[1].translationcache[Text] || Text;
-			PostTranslationRecord.push([Name, Text]);
-		} else console.log("ERROR LOADING TEXT!!!");
-	}
-	if (ct == 0) KDLoadingTextKeys[Name] = Text;
-}
-function deleteTextKey(Name: string) {
-	let ct = 0;
-	for (let screen of TextAllScreenCache.entries()) {
-		if (screen[0].includes("KinkyDungeon")) {
-			delete screen[1].cache[Name];
-		} else console.log("ERROR LOADING TEXT!!!");
-	}
-	if (ct == 0) delete KDLoadingTextKeys[Name];
-}
 
 const cloneDeep = (obj: any) =>
 	JSON.parse(JSON.stringify(obj));
@@ -544,12 +520,4 @@ function HasPerk(perk: string): boolean {
  */
 function KDPlayer(): entity {
 	return KinkyDungeonPlayerEntity;
-}
-
-function ExportMissingCSVLines() {
-	let str = "";
-	for (let [k,v] of Object.entries(MissingCSVTranslation)) {
-		str = str + k + ',"' + v + '"\n';
-	}
-	return str;
 }

--- a/Scripts/Common.ts
+++ b/Scripts/Common.ts
@@ -167,40 +167,6 @@ function CommonParseCSV(str: string): string[][] {
 }
 
 /**
- *  Read a CSV file from cache, or fetch it from the server
- * @param Array - Name of where the cached text is stored
- * @param Path - Path/Group in which the screen is located
- * @param Screen - Screen for which the file is for
- * @param File - Name of the file to get
- */
-function CommonReadCSV(Array: string, Path: string, Screen: string, File: string): void {
-
-	// Changed from a single path to various arguments and internally concatenate them
-	// This ternary operator is used to keep backward compatibility
-	let FullPath = "Screens/" + Path + "/" + Screen + "/" + File + ".csv";
-	if (CommonCSVCache[FullPath]) {
-		window[Array] = CommonCSVCache[FullPath];
-		return;
-	}
-
-	// Opens the file, parse it and returns the result in an Object
-	CommonGet(FullPath, function () {
-		if (this.status == 200) {
-			CommonCSVCache[FullPath] = CommonParseCSV(this.responseText);
-			window[Array] = CommonCSVCache[FullPath];
-		}
-	});
-
-	// If a translation file is available, we open the txt file and keep it in cache
-	let TranslationPath = FullPath.replace(".csv", "_" + TranslationLanguage + ".txt");
-	if (TranslationAvailable(TranslationPath))
-		CommonGet(TranslationPath, function () {
-			if (this.status == 200) TranslationCache[TranslationPath] = TranslationParseTXT(this.responseText);
-		});
-
-}
-
-/**
  * AJAX utility to get a file and return its content. By default will retry requests 10 times
  * @param Path - Path of the resource to request
  * @param Callback - Callback to execute once the resource is received

--- a/Scripts/Text.ts
+++ b/Scripts/Text.ts
@@ -1,273 +1,622 @@
-let TextScreenCache: TextCache | null = null;
-const TextAllScreenCache: Map<string, TextCache> = new Map();
+// Manages paths for localization resource files
+class LocalizationPathManager {
+	static readonly BASE_PATH = "Screens/MiniGame/KinkyDungeon";
 
-/**
- * Finds the text value linked to the tag in the buffer
- * @param TextTag - Tag for the text to find
- * @returns Returns the text associated to the tag, will return a missing tag text if the tag was not found.
- */
-function TextGet(TextTag: string): string {
-	return TextScreenCache ? TextScreenCache.get(TextTag) : "";
-}
+	static getDefTranslationPath(language: string): string {
+		return `${this.BASE_PATH}/Text_KinkyDungeon_${language.toUpperCase()}.txt`;
+	}
 
-/**
- * Loads the CSV text file of the current screen into the buffer. It will get the CSV from the cache if the file was already fetched from
- * the server
- * @param TextGroup - Screen for which to load the CSV of
- */
-function TextLoad(TextGroup: string = null): void {
-
-	// Finds the full path of the CSV file to use cache
-	if ((TextGroup == null) || (TextGroup == "")) TextGroup = CurrentScreen;
-	const FullPath = "Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv";
-
-	TextScreenCache = TextAllScreenCache.get(FullPath);
-	if (!TextScreenCache) {
-		TextScreenCache = new TextCache(FullPath, "");
-		TextAllScreenCache.set(FullPath, TextScreenCache);
+	static getOriginalCSVPath(): string {
+		return `${this.BASE_PATH}/Text_KinkyDungeon.csv`;
 	}
 }
 
-/**
- * Cache the Module and TextGroup for later use, speeds up first use
- */
-function TextPrefetch(Module: string, TextGroup: string): void {
-	const FullPath = "Screens/" + Module + "/" + TextGroup + "/Text_" + TextGroup + ".csv";
-	if (TextAllScreenCache.has(FullPath)) {
-		TextAllScreenCache.set(FullPath, new TextCache(FullPath, "MISSING VALUE FOR TAG: "));
-	}
-}
+// Configuration options for resource loading
+type ResourceLoadOptions = {
+	requestInit?: RequestInit;
+	signal?: AbortSignal;
+	nocache?: boolean;
+	retries?: number;
+};
 
-/**
- * A class that can be used to cache a simple key/value CSV file for easy text lookups. Text lookups will be automatically translated to
- * the game's current language, if a translation is available.
- */
-class TextCache {
+type ResourceParser<T> = (response: Response) => Promise<T>;
 
-	private path: string;
-	private warn: string;
-	private language: string;
-	cache: Record<string, string>;
-	translationcache: any;
-	private rebuildListeners: any[];
-	private loaded: boolean;
+// Handles resource loading with caching and retry mechanism
+class ResourceLoader {
+	private static cache = new Map<string, any>();
 
-	/**
-	 * Creates a new TextCache from the provided CSV file path.
-	 * @param path - The path to the CSV lookup file for this TextCache instance
-	 * @param warn - prefix for warning when key is not found
-	 */
-	constructor(path: string, warn: string = "") {
-		this.path = path;
-		this.warn = warn;
-		this.language = TranslationLanguage;
-		this.cache = {};
-		this.translationcache = {};
-		this.rebuildListeners = [];
-		this.loaded = false;
-		this.buildCache();
+	private static parserRegistry = new Map<string, ResourceParser<any>>([
+		["text", (r) => r.text()],
+		["json", (r) => r.json()],
+		["blob", (r) => r.blob()],
+	]);
+
+	static registerParser<T>(type: string, parser: ResourceParser<T>) {
+		this.parserRegistry.set(type, parser);
 	}
 
-	/**
-	 * Gets the current translation path
-	 * @returns {string}
-	 */
-	public getPath(): string {
-		const lang = (TranslationLanguage || "").trim().toUpperCase();
-		return this.path.replace(/\/([^/]+)\.csv$/, `/$1_${lang}.txt`);
-	}
-
-	/**
-	 * Looks up a string from this TextCache. If the cache contains a value for the provided key and a translation is available, the return
-	 * value will be automatically translated. Otherwise the EN string will be used. If the cache does not contain a value for the requested
-	 * key, the key will be returned.
-	 * @param key - The text key to lookup
-	 * @returns The text value corresponding to the provided key, translated into the current language, if available
-	 */
-	get(key: string): string {
-		if (!this.loaded) return "";
-		if (TranslationLanguage !== this.language) {
-			this.buildCache();
+	static async load<T>(
+		url: string,
+		type: string,
+		options?: ResourceLoadOptions
+	): Promise<T> {
+		// Caching can lead to memory leaks, need to improve recycling strategy before enabling
+		options.nocache = true;
+		const cached = this.cache.get(url);
+		if (cached && !options?.nocache) {
+			return cached;
 		}
-		const value = this.cache[key];
-		return (value != null) ? value : (this.warn + key);
+
+		const response = await this.fetchWithRetry(url, options);
+		const parser = this.parserRegistry.get(type);
+
+		if (!parser) {
+			throw new Error(`No parser registered for type: ${type}`);
+		}
+
+		return parser(response);
 	}
 
-	/**
-	 * Adds a callback function as a rebuild listener. Rebuild listeners will
-	 * be called whenever the cache has completed a rebuild (either after
-	 * initial construction, or after a language change).
-	 * @param callback - The callback to register
-	 * @param immediate - Whether or not the callback should be called on registration
-	 * @returns A callback function which can be used to unsubscribe the added listener
-	 */
-	onRebuild(callback: Function, immediate: boolean = true): Function {
-		if (typeof callback === "function") {
-			this.rebuildListeners.push(callback);
-			if (immediate) {
-				callback();
+	private static async fetchWithRetry(
+		url: string,
+		options?: ResourceLoadOptions
+	): Promise<Response> {
+		const retries = options?.retries ?? 3;
+		let attempt = 0;
+
+		while (attempt <= retries) {
+			try {
+				const response = await fetch(url, {
+					...options?.requestInit,
+					signal: options?.signal,
+				});
+				if (response.ok) return response;
+				throw new Error(`HTTP ${response.status}`);
+			} catch (error) {
+				if (++attempt > retries) throw error;
+				await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt)));
 			}
-			return () => {
-				this.rebuildListeners = this.rebuildListeners.filter((listener) => listener !== callback);
-			};
 		}
-		return CommonNoop;
+		throw new Error("Unreachable");
+	}
+}
+
+// Parses translation text files into structured format
+class TranslationTextParser {
+	static parseLines(text: string): string[] {
+		return text.split(/\r?\n/);
+	}
+
+	static parseTranslationText(text: string): LocalizationResources {
+		const textTranslationMap = new Map<string, string>();
+		const tagTranslationMap = new Map<string, string>();
+
+		const lines = this.parseLines(text);
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i].trimStart();
+
+			if (line.startsWith("-")) {
+				textTranslationMap.set(line.slice(1).trim(), lines[++i].trimStart());
+			} else if (line.startsWith("::")) {
+				tagTranslationMap.set(line.slice(2).trim(), lines[++i].trimStart());
+			}
+		}
+
+		return { textTranslationMap, tagTranslationMap };
+	}
+}
+
+ResourceLoader.registerParser("original-csv", async (r) => {
+	const text = await r.text();
+	return new Map(CommonParseCSV(text).map(([key, value]) => [key, value]));
+});
+
+ResourceLoader.registerParser("translation-txt", async (r) => {
+	const text = await r.text();
+	return TranslationTextParser.parseTranslationText(text);
+});
+
+type TextResKey = string;
+type TextResValue = string;
+
+type OriginalTextMap = Map<TextResKey, TextResValue>;
+type TranslationTextMap = Map<TextResKey, TextResValue>;
+
+type LocalizationResources = {
+	textTranslationMap: TranslationTextMap;
+	tagTranslationMap: TranslationTextMap;
+};
+
+type TextGroupId = string;
+type ResourceUrl = string;
+
+/**
+ * Manages groups of source text resources
+ */
+class TextGroupManager {
+	private sourceTextGroupMap: Map<TextGroupId, OriginalTextMap> = new Map();
+
+	/**
+	 * Set group (note, this will directly overwrite)
+	 * @param sourceText Original text mapping
+	 */
+	public setGroup(groupId: TextGroupId, sourceText: OriginalTextMap): void {
+		this.sourceTextGroupMap.set(groupId, sourceText);
+	}
+
+	public removeGroup(groupId: TextGroupId): void {
+		this.sourceTextGroupMap.delete(groupId);
+	}
+	// Get group (create if not exists)
+	public getGroup(groupId: TextGroupId): OriginalTextMap {
+		let group = this.sourceTextGroupMap.get(groupId);
+		if (!group) {
+			group = new Map();
+			this.setGroup(groupId, group);
+		}
+		return group;
 	}
 
 	/**
-	 * Kicks off a build of the text lookup cache
+	 * Appends a source text map to an existing text group identified by the given groupId.
+	 *
+	 * @param groupId - The identifier of the text group to which the source text map will be appended.
+	 * @param sourceText - The original text map that will be merged into the existing text group.
+	 * @returns void
 	 */
-	buildCache(): void {
-		if (!this.path) return;
-		this.fetchCsv()
-			.then((lines) => {
-				return  this.translate(lines);
-			})
-			.then((lines) => {
-				return this.cacheLines(lines);
-			})
-			.then(() => {
-				this.rebuildListeners.forEach((listener) => listener(this));
-			});
+	public appendTextMap(
+		groupId: TextGroupId,
+		sourceText: OriginalTextMap
+	): void {
+		const group = this.getGroup(groupId);
+		this.mergeMaps(group, sourceText);
 	}
 
 	/**
-	 * Fetches and parses the CSV file for this TextCache
-	 * @returns A promise resolving to an array of string arrays, corresponding to lines of CSV values in the CSV
-	 * file.
+	 * Appends a text resource to the specified group.
+	 *
+	 * @param groupId - The identifier of the text group to which the text resource will be appended.
+	 * @param key - The key for the text resource.
+	 * @param value - The value of the text resource.
 	 */
-	fetchCsv(): Promise<string[][]> {
-		if (CommonCSVCache[this.path]) return Promise.resolve(CommonCSVCache[this.path]);
-		return new Promise((resolve) => {
-			CommonGet(this.path, (xhr) => {
-				if (xhr.status === 200) {
-					CommonCSVCache[this.path] = CommonParseCSV(xhr.responseText);
-					return resolve(CommonCSVCache[this.path]);
-				}
-				return Promise.resolve([]);
-			});
+	public appendText(
+		groupId: TextGroupId,
+		key: TextResKey,
+		value: TextResValue
+	): void {
+		this.appendTextMap(groupId, new Map([[key, value]]));
+	}
+
+	private mergeMaps<T>(target: Map<string, T>, source: Map<string, T>) {
+		source.forEach((v, k) => target.set(k, v));
+	}
+}
+
+type LanguageIdentifier = 'CN' | 'DE' | 'ES' | 'JP' | 'KR' | 'RU' | 'EN';
+
+// Handles language-specific translation operations
+class LocalizationService {
+	private currentLanguage: LanguageIdentifier = "EN";
+
+	private localizationMap: Map<LanguageIdentifier, LocalizationResources> =
+		new Map();
+
+	public getCurrentTranslation(): LocalizationResources | null {
+		return this.localizationMap.get(this.currentLanguage) || null;
+	}
+
+	/**
+	 * Sets the translation for a specific language.
+	 *
+	 * @param language - The identifier of the language for which the translation is being set.
+	 * @param translation - The localization resources containing the translation data.
+	 */
+	public setTranslation(
+		language: LanguageIdentifier,
+		translation: LocalizationResources
+	): void {
+		this.localizationMap.set(language, translation);
+	}
+
+	/**
+	 * Appends a translation to the existing localization map for a given language.
+	 * If the language does not exist in the map, it adds the new translation.
+	 * If the language already exists, it merges the new translation with the existing one.
+	 *
+	 * @param language - The identifier of the language for which the translation is being added.
+	 * @param translation - The localization resources to be appended.
+	 * @returns void
+	 */
+	public appendTranslation(
+		language: LanguageIdentifier,
+		translation: LocalizationResources
+	): void {
+		const current = this.localizationMap.get(language);
+		if (!current) {
+			this.localizationMap.set(language, translation);
+		} else {
+			this.mergeLocalizationResources(current, translation);
+		}
+	}
+
+	private mergeLocalizationResources(
+		target: LocalizationResources,
+		source: LocalizationResources
+	): void {
+		source.textTranslationMap.forEach((v, k) =>
+			target.textTranslationMap.set(k, v)
+		);
+		source.tagTranslationMap.forEach((v, k) =>
+			target.tagTranslationMap.set(k, v)
+		);
+	}
+
+	/**
+	 * Translates a given text resource key or value to the current localization.
+	 *
+	 * @param tag - The text resource key to be translated.
+	 * @param text - The text resource value to be translated.
+	 * @returns The translated string if found, otherwise `null`.
+	 */
+	public translate(tag: TextResKey, text: TextResValue): string | null {
+		const currentLocalization = this.getCurrentTranslation();
+		if (!currentLocalization) {
+			return null;
+		}
+
+		const translation = currentLocalization.tagTranslationMap.get(tag);
+		if (translation) {
+			return translation;
+		}
+
+		return currentLocalization.textTranslationMap.get(text) || null;
+	}
+
+	/**
+	 * Sets the current language of the TextResourceManager.
+	 *
+	 * @param lang - The language identifier to set as the current language.
+	 * @returns A promise that resolves when the language has been set.
+	 */
+	public async setLanguage(lang: LanguageIdentifier): Promise<void> {
+		if (this.currentLanguage === lang) {
+			return;
+		}
+
+		this.currentLanguage = lang;
+	}
+}
+
+type LocalizationFileUrlMap = Map<LanguageIdentifier, ResourceUrl>;
+
+type TextResourceConfig = {
+	groupId: TextGroupId; // group id
+	original: ResourceUrl; // original text resource url
+	localizationDictionary: LocalizationFileUrlMap; // translation text resource url
+
+	lazyLoad?: boolean; // no support yet
+};
+
+// 资源加载PromiseMap
+type ResourceLoadPromiseMap = Map<ResourceUrl, Promise<void>>;
+
+type TemplateParams = { [key: string]: string | number | boolean };
+
+// 资源加载器
+// 提供资源加载的状态管理, 缓存, 终止
+class TextResourceLoader<T> {
+	// 加载器缓存, 如果失败不会缓存
+	private resourcePromiseCache: Map<ResourceUrl, Promise<T>> = new Map();
+	private abortController = new AbortController();
+
+	/**
+	 * Pushes a load request for a resource and returns a promise that resolves with the resource.
+	 * If the resource is already being loaded, the existing promise is returned.
+	 *
+	 * @template T - The type of the resource being loaded.
+	 * @param {ResourceUrl} url - The URL of the resource to load.
+	 * @param {string} loadType - The type of load operation to perform.
+	 * @returns {Promise<T>} A promise that resolves with the loaded resource.
+	 *
+	 * @throws Will log an error and remove the resource from the cache if the load fails.
+	 */
+	pushLoad(url: ResourceUrl, loadType: string): Promise<T> {
+		const cached = this.resourcePromiseCache.get(url);
+		if (cached) return cached;
+
+		const promise = ResourceLoader.load<T>(url, loadType, {
+			signal: this.abortController.signal,
+		});
+		promise.catch(() => {
+			console.error(`Loading resource failed: ${url}`);
+
+			this.resourcePromiseCache.delete(url);
+		});
+
+		this.resourcePromiseCache.set(url, promise);
+		return promise;
+	}
+
+	abortAll(): void {
+		this.abortController.abort();
+		this.abortController = new AbortController();
+	}
+
+	isLoaded(): boolean {
+		return this.resourcePromiseCache.size === 0;
+	}
+
+	clearCache(): void {
+		this.resourcePromiseCache.clear();
+	}
+
+	/**
+	 * Waits for all resource promises in the cache to resolve.
+	 *
+	 * @returns {Promise<void>} A promise that resolves when all resource promises have resolved.
+	 */
+	async waitAll(): Promise<void> {
+		await Promise.all(this.resourcePromiseCache.values());
+	}
+}
+
+// Singleton class for unified text resource management
+// Methods use the default group by default. To operate on a specific group, please get the corresponding manager/service first.
+class TextProvider {
+	private static _instance: TextProvider = new TextProvider();
+
+	public readonly defaultGroupId = "default";
+	private _debugMode = false;
+	private currentLanguage: LanguageIdentifier = null;
+
+	private textGroupManager: TextGroupManager = new TextGroupManager();
+	private translationServiceGroup: Map<TextGroupId, LocalizationService> =
+		new Map();
+
+	private originalTextLoader = new TextResourceLoader<OriginalTextMap>();
+	private translationTextLoader =
+		new TextResourceLoader<LocalizationResources>();
+
+	private textResourceConfig: TextResourceConfig[] = [];
+
+	private constructor() {
+		this.initializeDefaultConfig();
+	}
+
+	/**
+	 * Appends a text resource configuration to the manager and sets up the original and translated text.
+	 *
+	 * @param config - The configuration object for the text resource.
+	 * @param config.groupId - The identifier for the group of text resources.
+	 * @param config.original - The original text to be loaded and set up.
+	 * @param config.localizationDictionary - A map containing translations for different languages.
+	 * @param config.localizationDictionary.has - Checks if a translation exists for the current language.
+	 * @param config.localizationDictionary.get - Retrieves the translation for the current language.
+	 *
+	 * This method performs the following steps:
+	 * 1. Adds the provided text resource configuration to the internal list.
+	 * 2. Loads and sets up the original text using the provided groupId and original text.
+	 * 3. Checks if a translation exists for the current language in the localization dictionary.
+	 * 4. If a translation exists, loads and sets up the translated text for the current language.
+	 */
+	public appendTextResource(config: TextResourceConfig) {
+		this.textResourceConfig.push(config);
+		this.loadAndSetupOriginalText(config.groupId, config.original);
+		const currentLang = this.currentLanguage;
+		if (!config.localizationDictionary.has(currentLang)) return;
+
+		this.loadAndSetupTranslationText(
+			config.groupId,
+			config.localizationDictionary.get(currentLang),
+			currentLang
+		);
+	}
+
+	/**
+	 * Initializes the default configuration for text resources.
+	 */
+	private initializeDefaultConfig() {
+		this.appendTextResource({
+			groupId: this.defaultGroupId,
+			original: LocalizationPathManager.getOriginalCSVPath(),
+			localizationDictionary: new Map([
+				["CN", LocalizationPathManager.getDefTranslationPath("CN")],
+				["DE", LocalizationPathManager.getDefTranslationPath("DE")],
+				["ES", LocalizationPathManager.getDefTranslationPath("ES")],
+				["JP", LocalizationPathManager.getDefTranslationPath("JP")],
+				["KR", LocalizationPathManager.getDefTranslationPath("KR")],
+				["RU", LocalizationPathManager.getDefTranslationPath("RU")]
+			]),
+		});
+	}
+
+	public setDebugMode(debug: boolean): void {
+		this._debugMode = debug;
+	}
+
+	public queryResourceConfig(groupId: TextGroupId): TextResourceConfig[] {
+		return this.textResourceConfig.filter(
+			(config) => config.groupId === groupId
+		);
+	}
+
+	public static get instance(): TextProvider {
+		return this._instance;
+	}
+
+	/**
+	 * Retrieves a text string from a specified group and tag, optionally applying template parameters.
+	 *
+	 * @param groupId - The identifier of the group from which to retrieve the text.
+	 * @param tag - The tag associated with the desired text within the group.
+	 * @param params - Optional template parameters to apply to the text.
+	 * @returns The retrieved text string, with template parameters applied if provided. If the text is not found, returns "[NotFound] " followed by the tag.
+	 */
+	getTextFromGroup(
+		groupId: TextGroupId,
+		tag: string,
+		params?: TemplateParams
+	): string {
+		const source = this.getGroupManager().getGroup(groupId);
+		const translationService = this.getTranslationService(groupId);
+		const sourceText = source.get(tag);
+
+		let text = translationService.translate(tag, sourceText) || sourceText;
+
+		if (text && params) {
+			text = TextProvider.applyTemplate(text, params);
+		}
+
+		if (this._debugMode) {
+			text = `${tag}::${text}`;
+		}
+
+		return text || "[NotFound] " + tag;
+	}
+
+	/**
+	 * Retrieves the text associated with the specified tag.
+	 *
+	 * @param tag - The tag identifying the text to retrieve.
+	 * @param params - Optional parameters to format the text.
+	 * @returns The text associated with the specified tag, formatted with the provided parameters if any.
+	 */
+	getText(tag: string, params?: TemplateParams): string {
+		return this.getTextFromGroup(this.defaultGroupId, tag, params);
+	}
+
+	/**
+	 * Retrieves the localization service for a given text group ID.
+	 * If the service does not already exist, it creates a new instance,
+	 * stores it in the translation service group, and then returns it.
+	 *
+	 * @param groupId - The identifier for the text group.
+	 * @returns The localization service associated with the given text group ID.
+	 */
+	getTranslationService(groupId: TextGroupId): LocalizationService {
+		let service = this.translationServiceGroup.get(groupId);
+		if (!service) {
+			service = new LocalizationService();
+			this.translationServiceGroup.set(groupId, service);
+		}
+		return service;
+	}
+
+	// Get text group manager
+	getGroupManager(): TextGroupManager {
+		return this.textGroupManager;
+	}
+
+	/**
+	 * Loads and sets up the original text for a given text group.
+	 *
+	 * This method pushes a load request for the original text from the specified URL,
+	 * and once the text is loaded, it appends the text map to the text group manager.
+	 *
+	 * @param groupId - The identifier of the text group to which the text will be appended.
+	 * @param url - The URL from which the original text will be loaded.
+	 */
+	loadAndSetupOriginalText(groupId: TextGroupId, url: ResourceUrl): void {
+		this.originalTextLoader.pushLoad(url, "original-csv").then((source) => {
+			this.textGroupManager.appendTextMap(groupId, source);
 		});
 	}
 
 	/**
-	 * Stores the contents of a CSV file in the TextCache's internal cache
-	 * @param lines - An array of string arrays corresponding to lines in the CSV file
-  	 * Update 15.12.2023 - Certain languages already have this.cache, so they are not processed
+	 * Loads and sets up translation text for a specified language and group.
+	 *
+	 * @param groupId - The identifier for the text group.
+	 * @param url - The URL from which to load the translation text.
+	 * @param language - The language identifier for the translation.
 	 */
-	cacheLines(lines: string[][]): void {
-		this.language = TranslationLanguage;
-		const lang = (TranslationLanguage || "").trim().toUpperCase();
-		if (lang !== "RU") {lines.forEach((line) => (this.cache[line[0]] = line[1]));}
-
-		let newRecord: [string, string][] = [];
-		for (let pair of PostTranslationRecord) {
-			if (this.translationcache[pair[1]]) {
-				this.cache[pair[0]] = this.translationcache[pair[1]] || pair[1];
-			} else newRecord.push(pair);
-		}
-		PostTranslationRecord = newRecord;
-		this.loaded = true;
-	}
-
-	/**
-	 * Translates the contents of a CSV file into the current game language
-	 * @param lines - An array of string arrays corresponding to lines in the CSV file
-	 * @returns A promise resolving to an array of string arrays corresponding to lines in the CSV file with the
-	 * values translated to the current game language
-	 */
-	translate(lines: string[][]): Promise<string[][]> {
-		this.language = TranslationLanguage;
-		const lang = (TranslationLanguage || "").trim().toUpperCase();
-		if (!lang || lang === "EN") return Promise.resolve(lines);
-
-		const translationPath = this.path.replace(/\/([^/]+)\.csv$/, `/$1_${lang}.txt`);
-		if (!TranslationAvailable(translationPath)) {
-			return Promise.resolve(lines);
-		}
-
-		if (TranslationCache[translationPath]) {
-			return Promise.resolve(this.buildTranslations(lines, TranslationCache[translationPath]));
-		} else {
-			return new Promise((resolve) => {
-				CommonGet(translationPath, (xhr) => {
-					if (xhr.status === 200) {
-						TranslationCache[translationPath] = TranslationParseTXT(xhr.responseText);
-						return resolve(this.buildTranslations(lines, TranslationCache[translationPath]));
-					}
-					return resolve(lines);
-				});
+	loadAndSetupTranslationText(
+		groupId: TextGroupId,
+		url: ResourceUrl,
+		language: LanguageIdentifier
+	) {
+		const translationService = this.getTranslationService(groupId);
+		this.translationTextLoader
+			.pushLoad(url, "translation-txt")
+			.then((translation) => {
+				translationService.appendTranslation(language, translation);
 			});
-		}
 	}
 
 	/**
-	 * Maps lines of a CSV to equivalent CSV lines with values translated according to the corresponding translation file
-	 * @param lines - An array of string arrays corresponding to lines in the CSV file
-	 * @param translations - An array of strings in translation file format (with EN and translated values on alternate lines)
-	 * @returns An array of string arrays corresponding to lines in the CSV file with the
-	 * values translated to the current game language
-  	 * Update 15.12.2023 - For certain languages (current only RU), the method of transferring to direct writing to this.cache via arrays has been changed
+	 * Sets the current language for the TextResourceManager. If the specified language
+	 * is different from the current language, it updates the current language and
+	 * reconfigures the text resources accordingly.
+	 *
+	 * @param language - The language identifier to set as the current language.
+	 *
+	 * This method performs the following steps:
+	 * 1. Checks if the specified language is different from the current language.
+	 * 2. Updates the current language.
+	 * 3. Iterates through the text resource configurations and updates the translation
+	 *    service for each group.
+	 * 4. Loads and sets up the translation text for the specified language if available.
+	 * 5. Clears the translation text cache after all translations have been loaded.
 	 */
-	buildTranslations(lines: string[][], translations: string[]): string[][] {
-		this.language = TranslationLanguage;
-		const lang = (TranslationLanguage || "").trim().toUpperCase();
-		let [translationsStringLineCache, translationsLineStringCache] = TranslationStringCachePreBuild(translations, "");
+	setLanguage(language: LanguageIdentifier): void {
+		if (this.currentLanguage === language) return;
+		this.currentLanguage = language;
 
+		this.textResourceConfig.forEach((config) => {
+			const groupId = config.groupId;
+			const localizationMap = config.localizationDictionary;
 
-		if (lang === "RU") {
-			lines.forEach((line, numberl) => (this.cache[line[0]] = this.buildTranslationsRU(line[1], lines, translations, numberl, translationsStringLineCache)));
+			const translationService = this.getTranslationService(groupId);
+			translationService.setLanguage(language);
 
-			for (let entry of translationsStringLineCache.entries()) {
-				if (!this.cache[entry[0]] && entry[1] % 2 == 0) // even only
-					this.translationcache[entry[0]] = translationsLineStringCache.get(entry[1] + 1);
-			}
-			return [];
-		}
+			if (!localizationMap.has(language)) return;
 
-		for (let entry of translationsStringLineCache.entries()) {
-			if (entry[1] % 2 == 0) // even only
-				this.translationcache[entry[0]] = translationsLineStringCache.get(entry[1] + 1);
-		}
+			this.loadAndSetupTranslationText(
+				groupId,
+				localizationMap.get(language),
+				language
+			);
+		});
 
-		return lines.map(line => ([line[0], TranslationStringCache(line[1], translationsStringLineCache, translationsLineStringCache)]));
+		this.translationTextLoader.waitAll().then(() => {
+			this.translationTextLoader.clearCache();
+		});
 	}
+
 	/**
-	* Translates a string to another language from the array,
-	* the translation is always the one right after the english line
-	* Works for certain languages as a replacement for TranslationStringCache
-	* And writes the string directly to this.cache
-	* @param S - The original english string to translate
-	* @param massiven - working array
-	* @param massivru - data from translation file
-	* @param numberl - index of lines array
-	* @param {Map<string, number>} translationsStringLineCache
-   	 */
-	buildTranslationsRU(S: string, massiven: string[][], massivru: string[], numberl: number, translationsStringLineCache): string {
-		if (S != null){
-			let S1 = S.trim();
-			if (S1 !== "") {
-				try {
-					let schet = 0;
-					for (let i = 0; i < numberl; i++) {
-						if (S1 === massiven[i][1]) {schet = schet + 1;}
-					}
-					for (let i = 0; i < (massivru.length); i++) {
-						if (S1 === massivru[i] && schet === 0) {
-							let s = massivru[i + 1];
-							if (s) {
-								return s;
-							}
-							return S;
-						} else if (S1 === massivru[i] && schet > 0) {
-							schet = schet - 1;
-						}
-					}
-				}
-				catch (e) {
-                		console.warn('TranslationStringCache catch:', S, translationsStringLineCache.get(S1), e);
-				}
-			}
-		}
-	return S;
+	 * Asynchronously waits for all text resources to be loaded by both the original and translation text loaders.
+	 *
+	 * @returns {Promise<TextProvider>} A promise that resolves to the current instance of TextProvider once all text resources are loaded.
+	 */
+	async readyAll(): Promise<TextProvider> {
+		await this.originalTextLoader.waitAll();
+		await this.translationTextLoader.waitAll();
+
+		return this;
 	}
+
+	static applyTemplate(text: string, params: TemplateParams): string {
+		return text.replace(/\$\{(\w+)\}/g, (match, key) => {
+			const value = params[key];
+			return value !== undefined ? String(value) : match;
+		});
+	}
+}
+
+const textProvider = TextProvider.instance;
+
+// === Compatible with old interfaces ===
+
+function TextGet(TextTag: string, params?: TemplateParams): string {
+	return textProvider.getText(TextTag, params);
+}
+
+function TextLoad(): void {
+	textProvider.setLanguage(TranslationLanguage as LanguageIdentifier);
+}
+
+
+function addTextKey(Name: string, Text: string) {
+	textProvider
+		.getGroupManager()
+		.appendText("default", Name, Text);
 }

--- a/Scripts/Text.ts
+++ b/Scripts/Text.ts
@@ -1,13 +1,33 @@
-// Manages paths for localization resource files
-class LocalizationPathManager {
+/**
+ *  Manages the generation of file paths for localization resources.
+ */
+class TextResPathGenerator {
 	static readonly BASE_PATH = "Screens/MiniGame/KinkyDungeon";
+	private file_path: string;
+	private file_prefix: string;
 
-	static getDefTranslationPath(language: string): string {
-		return `${this.BASE_PATH}/Text_KinkyDungeon_${language.toUpperCase()}.txt`;
+	constructor(base_path: string, file_prefix: string) {
+		this.file_path = base_path;
+		this.file_prefix = file_prefix;
 	}
 
-	static getOriginalCSVPath(): string {
-		return `${this.BASE_PATH}/Text_KinkyDungeon.csv`;
+	genOriginalPath() {
+		return `${this.file_path}/${this.file_prefix}.csv`;
+	}
+
+	genTranslationPath(language: string) {
+		return `${this.file_path}/${this.file_prefix
+			}_${language.toUpperCase()}.txt`;
+	}
+
+	genTranslationMap(
+		allowed_languages: LanguageIdentifier[]
+	): Map<LanguageIdentifier, ResourceUrl> {
+		let map = new Map<LanguageIdentifier, ResourceUrl>();
+		allowed_languages.forEach((lang) => {
+			map.set(lang, this.genTranslationPath(lang));
+		});
+		return map;
 	}
 }
 
@@ -116,15 +136,23 @@ ResourceLoader.registerParser("translation-txt", async (r) => {
 	return TranslationTextParser.parseTranslationText(text);
 });
 
+/**
+ * ===== Type Definitions =====
+ */
+const AvaliableLanguages = ["EN", "CN", "DE", "ES", "JP", "KR", "RU"] as const;
+type LanguageIdentifier = (typeof AvaliableLanguages)[number];
+const NormalSupportedLanguages = AvaliableLanguages.filter(
+	(lang) => lang !== "EN"
+);
+
 type TextResKey = string;
 type TextResValue = string;
 
-type OriginalTextMap = Map<TextResKey, TextResValue>;
-type TranslationTextMap = Map<TextResKey, TextResValue>;
+type TextResMap = Map<TextResKey, TextResValue>;
 
 type LocalizationResources = {
-	textTranslationMap: TranslationTextMap;
-	tagTranslationMap: TranslationTextMap;
+	textTranslationMap: TextResMap;
+	tagTranslationMap: TextResMap;
 };
 
 type TextGroupId = string;
@@ -134,13 +162,13 @@ type ResourceUrl = string;
  * Manages groups of source text resources
  */
 class TextGroupManager {
-	private sourceTextGroupMap: Map<TextGroupId, OriginalTextMap> = new Map();
+	private sourceTextGroupMap: Map<TextGroupId, TextResMap> = new Map();
 
 	/**
 	 * Set group (note, this will directly overwrite)
 	 * @param sourceText Original text mapping
 	 */
-	public setGroup(groupId: TextGroupId, sourceText: OriginalTextMap): void {
+	public setGroup(groupId: TextGroupId, sourceText: TextResMap): void {
 		this.sourceTextGroupMap.set(groupId, sourceText);
 	}
 
@@ -148,7 +176,7 @@ class TextGroupManager {
 		this.sourceTextGroupMap.delete(groupId);
 	}
 	// Get group (create if not exists)
-	public getGroup(groupId: TextGroupId): OriginalTextMap {
+	public getGroup(groupId: TextGroupId): TextResMap {
 		let group = this.sourceTextGroupMap.get(groupId);
 		if (!group) {
 			group = new Map();
@@ -164,10 +192,7 @@ class TextGroupManager {
 	 * @param sourceText - The original text map that will be merged into the existing text group.
 	 * @returns void
 	 */
-	public appendTextMap(
-		groupId: TextGroupId,
-		sourceText: OriginalTextMap
-	): void {
+	public appendTextMap(groupId: TextGroupId, sourceText: TextResMap): void {
 		const group = this.getGroup(groupId);
 		this.mergeMaps(group, sourceText);
 	}
@@ -191,8 +216,6 @@ class TextGroupManager {
 		source.forEach((v, k) => target.set(k, v));
 	}
 }
-
-type LanguageIdentifier = 'CN' | 'DE' | 'ES' | 'JP' | 'KR' | 'RU' | 'EN';
 
 // Handles language-specific translation operations
 class LocalizationService {
@@ -297,15 +320,11 @@ type TextResourceConfig = {
 	lazyLoad?: boolean; // no support yet
 };
 
-// 资源加载PromiseMap
-type ResourceLoadPromiseMap = Map<ResourceUrl, Promise<void>>;
-
 type TemplateParams = { [key: string]: string | number | boolean };
-
-// 资源加载器
-// 提供资源加载的状态管理, 缓存, 终止
+// Resource Loader
+// Provides resource loading state management, caching, and termination
 class TextResourceLoader<T> {
-	// 加载器缓存, 如果失败不会缓存
+	// Loader cache, will not cache if failed
 	private resourcePromiseCache: Map<ResourceUrl, Promise<T>> = new Map();
 	private abortController = new AbortController();
 
@@ -373,7 +392,7 @@ class TextProvider {
 	private translationServiceGroup: Map<TextGroupId, LocalizationService> =
 		new Map();
 
-	private originalTextLoader = new TextResourceLoader<OriginalTextMap>();
+	private originalTextLoader = new TextResourceLoader<TextResMap>();
 	private translationTextLoader =
 		new TextResourceLoader<LocalizationResources>();
 
@@ -381,6 +400,49 @@ class TextProvider {
 
 	private constructor() {
 		this.initializeDefaultConfig();
+	}
+
+	/**
+	 * Initializes the default configuration for text resources.
+	 */
+	private initializeDefaultConfig() {
+		const pathGener = new TextResPathGenerator(
+			"Screens/MiniGame/KinkyDungeon",
+			"Text_KinkyDungeon"
+		);
+
+		this.appendTextResource({
+			groupId: this.defaultGroupId,
+			original: pathGener.genOriginalPath(),
+			localizationDictionary: pathGener.genTranslationMap(
+				NormalSupportedLanguages
+			),
+		});
+	}
+
+	public setDebugMode(debug: boolean): void {
+		this._debugMode = debug;
+	}
+
+	public static get instance(): TextProvider {
+		return this._instance;
+	}
+
+	/**
+	 * Retrieves the text associated with the specified tag.
+	 *
+	 * @param tag - The tag identifying the text to retrieve.
+	 * @param params - Optional parameters to format the text.
+	 * @returns The text associated with the specified tag, formatted with the provided parameters if any.
+	 */
+	getText(tag: string, params?: TemplateParams): string {
+		return this.getTextFromGroup(this.defaultGroupId, tag, params);
+	}
+
+	public queryResourceConfig(groupId: TextGroupId): TextResourceConfig[] {
+		return this.textResourceConfig.filter(
+			(config) => config.groupId === groupId
+		);
 	}
 
 	/**
@@ -413,38 +475,6 @@ class TextProvider {
 	}
 
 	/**
-	 * Initializes the default configuration for text resources.
-	 */
-	private initializeDefaultConfig() {
-		this.appendTextResource({
-			groupId: this.defaultGroupId,
-			original: LocalizationPathManager.getOriginalCSVPath(),
-			localizationDictionary: new Map([
-				["CN", LocalizationPathManager.getDefTranslationPath("CN")],
-				["DE", LocalizationPathManager.getDefTranslationPath("DE")],
-				["ES", LocalizationPathManager.getDefTranslationPath("ES")],
-				["JP", LocalizationPathManager.getDefTranslationPath("JP")],
-				["KR", LocalizationPathManager.getDefTranslationPath("KR")],
-				["RU", LocalizationPathManager.getDefTranslationPath("RU")]
-			]),
-		});
-	}
-
-	public setDebugMode(debug: boolean): void {
-		this._debugMode = debug;
-	}
-
-	public queryResourceConfig(groupId: TextGroupId): TextResourceConfig[] {
-		return this.textResourceConfig.filter(
-			(config) => config.groupId === groupId
-		);
-	}
-
-	public static get instance(): TextProvider {
-		return this._instance;
-	}
-
-	/**
 	 * Retrieves a text string from a specified group and tag, optionally applying template parameters.
 	 *
 	 * @param groupId - The identifier of the group from which to retrieve the text.
@@ -472,17 +502,6 @@ class TextProvider {
 		}
 
 		return text || "[NotFound] " + tag;
-	}
-
-	/**
-	 * Retrieves the text associated with the specified tag.
-	 *
-	 * @param tag - The tag identifying the text to retrieve.
-	 * @param params - Optional parameters to format the text.
-	 * @returns The text associated with the specified tag, formatted with the provided parameters if any.
-	 */
-	getText(tag: string, params?: TemplateParams): string {
-		return this.getTextFromGroup(this.defaultGroupId, tag, params);
 	}
 
 	/**

--- a/Scripts/Translation.ts
+++ b/Scripts/Translation.ts
@@ -5,17 +5,18 @@ let TranslationCache: Record<string, string[]> = {};
  * Loads the previous translation language from local storage if it exists
  */
 function TranslationLoad(): void {
-  let language =
-    localStorage.getItem("LanguageChange") === "1"
-      ? localStorage.getItem("BondageClubLanguage")
-      : GetUserPreferredLanguage();
+	let language;
+	if (localStorage.getItem("LanguageChange") == "1")
+	{
+		language = localStorage.getItem("BondageClubLanguage");
+	}
+	else
+	{
+		language = GetUserPreferredLanguage();
+		if (language != null) localStorage.setItem("BondageClubLanguage",language);
+	}
 
-  if (language) {
-    localStorage.setItem("BondageClubLanguage", language);
-    TranslationLanguage = language;
-  }
-
-  TranslationLanguage = "EN";
+	if (language != null) TranslationLanguage = language;
 }
 
 function GetUserPreferredLanguage() {

--- a/Scripts/Translation.ts
+++ b/Scripts/Translation.ts
@@ -2,360 +2,41 @@ let TranslationLanguage = "EN";
 let TranslationCache: Record<string, string[]> = {};
 
 /**
- * Dictionary for all supported languages and their files
- * @constant
- */
-let TranslationDictionary = [
-
-	{
-		LanguageCode: "EN",
-		LanguageName: "English",
-		EnglishName: "English",
-		Files: [
-		]
-	},
-	{
-		LanguageCode: "DE",
-		LanguageName: "Deutsch",
-		EnglishName: "German",
-		Files: [
-			"Assets/Female3DCG/Female3DCG_DE.txt",
-		]
-	},
-	{
-		LanguageCode: "FR",
-		LanguageName: "Français",
-		EnglishName: "French",
-		Files: [
-			"Assets/Female3DCG/ColorGroups_FR.txt",
-			"Assets/Female3DCG/Female3DCG_FR.txt",
-			"Assets/Female3DCG/LayerNames_FR.txt",
-		]
-	},
-	{
-		LanguageCode: "RU",
-		LanguageName: "Русский",
-		EnglishName: "Russian",
-		Files: [
-			"Assets/Female3DCG/Female3DCG_RU.txt",
-			"Assets/Female3DCG/ColorGroups_RU.txt",
-			"Assets/Female3DCG/LayerNames_RU.txt",
-		]
-	},
-	{
-		LanguageCode: "CN",
-		LanguageName: "简体中文",
-		EnglishName: "Chinese",
-		Files: [
-			"Assets/Female3DCG/ColorGroups_CN.txt",
-			"Assets/Female3DCG/Female3DCG_CN.txt",
-			"Assets/Female3DCG/LayerNames_CN.txt",
-			"Screens/Character/Appearance/Text_Appearance_CN.txt",
-			"Screens/Character/BackgroundSelection/Text_BackgroundSelection_CN.txt",
-			"Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_CN.txt",
-		]
-	},
-	{
-		LanguageCode: "KR",
-		LanguageName: "한국어",
-		EnglishName: "Korean",
-		Files: [
-			"Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_KR.txt",
-		]
-	},
-	{
-		LanguageCode: "RU",
-		LanguageName: "한국어",
-		EnglishName: "Pусский",
-		Files: [
-			"Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_RU.txt",
-		]
-	},
-	{
-		LanguageCode: "JP",
-		LanguageName: "日本語",
-		EnglishName: "Japanese",
-		Files: [
-			"Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_JP.txt",
-		]
-	},
-	{
-		LanguageCode: "ES",
-		LanguageName: "Español",
-		EnglishName: "Spanish",
-		Files: [
-			"Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon_ES.txt",
-		]
-	},
-
-];
-
-/**
- * Checks if a file can be translated in the selected language
- * @param FullPath - Full path of the file to check for a corresponding translation file
- * @returns Returns TRUE if a translation is available for the given file
- */
-function TranslationAvailable(FullPath: string): boolean {
-	let FileName = FullPath.trim().toUpperCase();
-	for (let L = 0; L < TranslationDictionary.length; L++)
-		if (TranslationDictionary[L].LanguageCode == TranslationLanguage)
-			for (let F = 0; F < TranslationDictionary[L].Files.length; F++)
-				if (TranslationDictionary[L].Files[F].trim().toUpperCase() == FileName)
-					return true;
-	return false;
-}
-
-/**
- * Parse a TXT translation file and returns it as an array
- * @param str - Content of the translation text file
- * @returns Array of strings with each line divided. For each translated line, the english string precedes the translated one in the array.
- */
-function TranslationParseTXT(str: string): string[] {
-
-	const arr = [];
-	let c;
-	str = str.replace(/\r\n/g, '\n').trim();
-
-	// iterate over each character, keep track of current row (of the returned array)
-	for (let row = c = 0; c < str.length; c++) {
-		let cc = str[c];        // current character, next character
-		arr[row] = arr[row] || "";             // create a new row if necessary
-		if (cc == '\n') { ++row; continue; }   // If it's a newline, move on to the next row
-		arr[row] += cc;                        // Otherwise, append the current character to the row
-	}
-
-	// Removes any comment rows (starts with ### or empty)
-	for (let row = arr.length - 1; row >= 0; row--)
-		if (arr[row].indexOf("###") == 0 || arr[row].length == 0) {
-			arr.splice(row, 1);
-		}
-
-	// Trims the full translated array
-	for (let row = 0; row < arr.length; row++)
-		arr[row] = arr[row].trim();
-	return arr;
-}
-
-/**
- * Translates a string to another language from the array, the translation is always the one right after the english line
- * @param S - The original english string to translate
- * @param T - The active translation dictionary
- * @param CharacterName - Name of the character if it is required to replace it within the string.
- * @returns The translated string
- */
-function TranslationString(S: string, T: string[], CharacterName: string): string {
-	if ((S != null) && (S.trim() !== "")) {
-		S = S.trim();
-		for (let P = 0; P < T.length - 1; P++)
-			if (S === T[P])
-				return T[P + 1];
-	}
-	return S;
-}
-
-/**
- * build [translationsStringLineCache, translationsLineStringCache] for TranslationStringCache
- * @param translations - An array of strings in translation file format (with EN and translated values on alternate lines)
- * @param CharacterName - Name of the character if it is required to replace it within the string.
- * @returns The translated cache [translationsStringLineCache, translationsLineStringCache]
- */
-function TranslationStringCachePreBuild(translations: string[], CharacterName: string): [Map<string, number>, Map<number, string>] {
-	let translationsStringLineCache = new Map();
-	let translationsLineStringCache = new Map();
-	translations.forEach((T, i) => {
-		let S = T;
-		translationsStringLineCache.set(S, i);
-		translationsLineStringCache.set(i, S);
-	});
-	return [translationsStringLineCache, translationsLineStringCache];
-}
-
-/**
- * Translates a string to another language from the array,
- * the translation is always the one right after the english line
- * this is the cache mode of TranslationString
- * @param S - The original english string to translate
- * @param translationsStringLineCache - The active translation dictionary <string, stringLine>
- * @param translationsLineStringCache - The active translation dictionary <stringLine, string>
- * @returns The translated string
- */
-function TranslationStringCache(S: string, translationsStringLineCache: Map<string, number>, translationsLineStringCache: Map<number, string>): string {
-	if (S != null) {
-		let S1 = S.trim();
-		if (S1 !== "") {
-			try {
-				let l = translationsStringLineCache.get(S1);
-				if (l) {
-					// the translation is always the one right after the english line
-					let s = translationsLineStringCache.get(l + 1);
-					if (s) {
-						return s;
-					}
-					console.warn('TranslationStringCache lost translationsLineStringCache:', S, l);
-				}
-				return S;
-			} catch (e) {
-				// ignore
-				console.warn('TranslationStringCache catch:', S, translationsStringLineCache.get(S1), e);
-			}
-		}
-	}
-	return S;
-}
-
-
-/**
- * Translates a set of tags. Rerenders the login message when on the login page.
- * @param S - Array of current tag-value pairs
- * @param T - The active translation dictionary
- */
-function TranslationTextArray(S: {Tag: string, Value: string}[], T: string[]): void {
-	for (let P = 0; P < S.length; P++)
-		S[P].Value = TranslationString(S[P].Value, T, "");
-}
-
-
-/**
- * Translate an array of tags in the current selected language
- * @param Text - Array of current tag-value pairs
- */
-function TranslationText(Text: {Tag: string, Value: string}[]): void {
-	// If we play in a foreign language
-	if ((TranslationLanguage != null) && (TranslationLanguage.trim() != "") && (TranslationLanguage.trim().toUpperCase() != "EN")) {
-
-		// Finds the full path of the translation file to use
-		let FullPath = "Screens/" + CurrentModule + "/" + CurrentScreen + "/Text_" + CurrentScreen + "_" + TranslationLanguage + ".txt";
-
-		// If the translation file is already loaded, we translate from it
-		if (TranslationCache[FullPath]) {
-			TranslationTextArray(Text, TranslationCache[FullPath]);
-			return;
-		}
-
-		// If the translation is available, we open the txt file, parse it and returns the result to build the dialog
-		if (TranslationAvailable(FullPath))
-			CommonGet(FullPath, function() {
-				if (this.status == 200) {
-					TranslationCache[FullPath] = TranslationParseTXT(this.responseText);
-					TranslationTextArray(Text, TranslationCache[FullPath]);
-				}
-			});
-
-	}
-
-}
-
-/**
- * Changes the current language and save the new selected language to local storage
- */
-function TranslationNextLanguage(): void {
-	for (let L = 0; L < TranslationDictionary.length; L++)
-		if (TranslationDictionary[L].LanguageCode == TranslationLanguage) {
-			if (L != TranslationDictionary.length - 1)
-				TranslationLanguage = TranslationDictionary[L + 1].LanguageCode;
-			else
-				TranslationLanguage = TranslationDictionary[0].LanguageCode;
-			localStorage.setItem("BondageClubLanguage", TranslationLanguage);
-			return;
-		}
-}
-
-/**
  * Loads the previous translation language from local storage if it exists
  */
 function TranslationLoad(): void {
-	let L;
-	if (localStorage.getItem("LanguageChange") == "1")
-	{
-		L = localStorage.getItem("BondageClubLanguage");
-	}
-	else
-	{
-		L = GetUserPreferredLanguage();
-		if (L != null) localStorage.setItem("BondageClubLanguage",L);
-	}
+  let language =
+    localStorage.getItem("LanguageChange") === "1"
+      ? localStorage.getItem("BondageClubLanguage")
+      : GetUserPreferredLanguage();
 
-	if (L != null) TranslationLanguage = L;
+  if (language) {
+    localStorage.setItem("BondageClubLanguage", language);
+    TranslationLanguage = language;
+  }
+
+  TranslationLanguage = "EN";
 }
 
 function GetUserPreferredLanguage() {
-	var languages;
-	try{languages = Intl.DateTimeFormat().resolvedOptions().locale.split('-');}
-	catch{languages = navigator.language.split('-');}
-	if (!languages) {
-		return "";
-	}
+  var languages;
+  try {
+    languages = Intl.DateTimeFormat().resolvedOptions().locale.split("-");
+  } catch {
+    languages = navigator.language.split("-");
+  }
+  if (!languages) {
+    return "";
+  }
 
-	for (let i = 0; i < languages.length; i++)
-	{
-		let lang = languages[i];
-		if (KDLanguages.includes(lang))
-			return lang;
-	}
-	return "";
-
+  for (let i = 0; i < languages.length; i++) {
+    let lang = languages[i];
+    if (KDLanguages.includes(lang)) return lang;
+  }
+  return "";
 }
-/**
- * Loads an array of texts loaded from a .csv file
- * @param text1 - Primary array to load - this will probably be English
- * @param text2 - Secondary array to load - this is probably a translation - This part might not be working?
- */
-function KDLoadTranslations(text1: string, text2: string = null) {
-	let parsedkeys = {};
-	let parsedkeystranslation = {};
-	const text1array = text1.replace(/\r\n?/g, '\n').trim().split('\n');
-	text1array.forEach((line: string) => {
-		try {
-			let keyloc = line.indexOf(",");
-			const textkey = line.slice(0,keyloc);
-			let val = line.slice(keyloc+1);
-			// Remove quotes if the value string has commas in it.
-			if ((val.startsWith('"') && (val.endsWith('"'))) || ((val.startsWith("'")) && (val.endsWith("'")))) {
-				val = val.slice(1,-1);
-			}
-			if (textkey === null || val === undefined) {
-				console.log("Error while parsing line: " + line);
-			}
-			else {
-				parsedkeys[textkey] = val;
-			}
-		}
-		catch (err) {
-			console.log(err);
-		}
-	})
-	if (text2 != null) {
-		const text2array = text2.replace(/\r\n?/g, '\n').trim().split('\n');
-		text2array.forEach((line: string) => {
-			try {
-				let keyloc = line.indexOf(",");
-				const textkey = line.slice(0,keyloc);
-				let val = line.slice(keyloc+1);
-				// Remove quotes if the value string has commas in it.
-				if ((val.startsWith('"') && (val.endsWith('"'))) || ((val.startsWith("'")) && (val.endsWith("'")))) {
-					val = val.slice(1,-1);
-				}
-				if (textkey === null || val === undefined) {
-					console.log("Error while parsing line: " + line);
-				}
-				else {
-					parsedkeystranslation[textkey] = val;
-				}
-			}
-			catch (err) {
-				console.log(err);
-			}
-		})
-	}
-	const keys = Object.keys(parsedkeys)
-	console.log(parsedkeys);
-	console.log(parsedkeystranslation);
-	keys.forEach((key: string) => {
-		if (parsedkeystranslation[key] != undefined) {
-			addTextKey(key, (parsedkeystranslation[key].slice('\r')));
-		}
-		else {
-			addTextKey(key, (parsedkeys[key].slice('\r')));
-		}
-	})
+
+// It won't work
+function KDLoadTranslations(text: string) {
+	// pass
 }


### PR DESCRIPTION
# Update Report

> _(Disclaimer) I rely on translation tools for communication. There may be cultural differences or inaccuracies in the expression or interpretation of sentences._
> _I always maintain a friendly attitude and have no intention of causing offense. If there are any misunderstandings or unclear meanings, please feel free to point them out._

## Update Overview

- Architecture Refactoring
- Improved Efficiency
- Enhanced Translation Precision Support
- Template String Support
- Maintained GetText Interface Compatibility (Original interfaces remain usable)
- Debugging mode for text (key will be displayed)

## Update Details

### - Template String Support for TextGet

Now supports template strings for translations. Examples:

```TypeScript
// Works with both TextProvider.instance.getText and legacy TextGet

// note: id_hi="Hi ${name}"

// String
TextGet("id_hi", {name: "World"});
// > "Hi World"

// Number
TextGet("id_hi", {name: 123});
// > "Hi 123"

// note: id_hi2="Hi ${name} ${name2}"

// Boolean (Though Boolean usage seems impractical)
TextGet("id_hi2", {name: Boolean("World"), name2: false});
// > "Hi true false"
```

### - Enhanced Translation Precision: New Translation Format

- Lines starting with `-` indicate source text matching
- Lines starting with `::` indicate exact tag matching
- The **immediately following line** contains the translation (even if empty, though empty translations won't be used)

Source text matching acts as fallback when no tag-specific translation exists.
Non-matching lines are ignored.

**Example Format:**
```txt
- original_text1
Translated_text_1
:: key_1
Translated_key_1

- original_text2
value_2

:: key_3
Translated_3
```

> Result:
> - `[tag:key_1, text:original_text1]` → Translated_key_1
> - `[tag:key_2, text:original_text1]` → Translated_text_1 (fallback to source text match)

### Debugging mode for text

You can enable debug mode by entering the following code in the console

```typescript
TextProvider.instance.setDebugMode(true);

// Example show Text > "KEY_SAVE::save"
```

### - Architectural Refactoring: Interface Changes

- `TextProvider` replaces `TextGet` as primary interface
- `TextGet` remains available as a wrapper for `TextProvider`

### Multi-Configuration Loading Support

Now supports loading multiple translation files or appending new entries:

```TypeScript
// Duplicate group IDs will merge. Default group: defaultGroupId
provider.appendTextResource({
  groupId: provider.defaultGroupId,
  original: "Screens/test/extra.csv",
  localizationDictionary: new Map([["CN", "Screens/test/extra_cn.txt"]]),
});
```

### Usage Examples and Tests

```typescript
const instance = TextProvider.instance;
instance.setLanguage("CN");

// Test 1: Basic translation
async function testBasicTranslation() {
  console.group("Basic Translation Test");
  await provider.readyAll();
  console.assert(provider.getText("SAVE") === "保存", "CN translation failed");

  provider.setLanguage("EN");
  await provider.readyAll();
  console.assert(provider.getText("SAVE") === "Save", "EN translation failed");
  console.groupEnd();
}

// Test 2: Template parameters
function testTemplateParams() {
  console.group("Template Test");
  provider.getGroupManager().appendText("default", "WELCOME", "欢迎${user}, 你有${count}条新消息");
  const result = provider.getText("WELCOME", { user: "Alice", count: 3 });
  console.assert(result === "欢迎Alice, 你有3条新消息", "Template failed");
  console.groupEnd();
}

// Test 3: Multiple groups
async function testMultipleGroups() {
  console.group("Group Management Test");
  provider.appendTextResource({
    groupId: "ui",
    original: "Screens/test/ui.csv",
    localizationDictionary: new Map([["CN", "Screens/test/ui_cn.txt"]]),
  });
  await provider.readyAll();
  console.assert(provider.getTextFromGroup("ui", "BUTTON_OK") === "确定", "Group failed");
  console.groupEnd();
}

// Test 4: Debug mode
function testDebugMode() {
  console.group("Debug Test");
  provider.setDebugMode(true);
  console.assert(provider.getText("SAVE") === "SAVE::保存", "Debug failed");
  provider.setDebugMode(false);
  console.groupEnd();
}

// Execute tests
async function runTests() {
  await testBasicTranslation();
  await testTemplateParams();
  await testMultipleGroups();
  await testDebugMode();
  console.log("All tests completed");
}

runTests();
```

**For guaranteed loading completion:**
```TypeScript
provider.readyAll().then(() => {
  console.log("Loaded:", provider.getText("key_1"));
});
```

### Other issues

#### - parseLines using Regex Performance

> It doesn't have much of an impact in practice, so use Regex to parse lines.

```shell
Normal: 2650ms
Regex: 2760ms
Difference: +110ms
```

#### - About variables and tagging
  I would prefer to call `tag` a `key`, but for the sake of consistency with the source code, I'll use `tag` for now.

#### - About trim
  Tramming a tag may allow unintended behavior, which should not be the case. 
  As for `translationByText`, matching by text has nothing to do with both ends, so it is trimmed.
  Although sometimes there may be an extra space that doesn't match the original text. 
  But I think, for the sake of an unnecessary space (like “A” versus “A[space]”), there is an extra match that needs to be translated, it doesn't really matter, you can use tag matching if you can't!

#### cache : about translate(tag: string, text: string) efficiency
  When a tag doesn't match, it tries to use a text translation.
  But for a Map, even one more get is negligible in terms of performance.
  Instead, the set operation is more time-consuming. You also have an additional memory overhead. So don't worry about duplicate fetches.

## Architecture Overview

> Note : 'Path Manager' rename to 'TextResPathGenerator'

```
1. Core Components
┌──────────────┐
│ TextProvider │ (Singleton Facade)
└──────────────┘
│
├─ TextGroupManager
├─ LocalizationService
├─ TextResourceLoader
├─ Configuration
└─ Language/Template handlers

2. Service Layer
┌───────────────────┐        ┌───────────────────┐
│ TextGroupManager  │        │ LocalizationService│
└───────────────────┘        └───────────────────┘
│ Manages text groups         │ Handles translations
│ - setGroup()               │ - setTranslation()
│ - appendTextMap()          │ - appendTranslation()

3. Loading Layer
┌───────────────────┐        ┌───────────────────┐
│ TextResourceLoader│        │ ResourceLoader    │
└───────────────────┘        └───────────────────┘
│ Advanced loading           │ Base loader
│ - Queue management         │ - Cached fetch
│ - Abort control            │ - Retry mechanism

4. Infrastructure
┌───────────────────┐        ┌──────────────────────┐
│ Path Manager      │        │ TranslationParser    │
└───────────────────┘        └──────────────────────┘
│ Path generation            │ Text parsing logic
```

![](https://github.com/user-attachments/assets/ead027a8-d3a3-4c6c-a597-172491a715ce)

![](https://github.com/user-attachments/assets/c34e63a8-0bce-43e9-b0c9-6598c805dc4b)

