### PR TITLE
4 pages of 4 save slots

### DIFF
--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -3004,24 +3004,27 @@ function KinkyDungeonRun() {
 			KDConfirmDeleteSave = false;
 		}
 
-		let offsets = [
-			{slot: 1, x: 1250 - 225 - 200, y: 650},
-			{slot: 2, x: 1250 - 225 - 200, y: 720},
-			{slot: 3, x: 1250 + 225 - 200, y: 650},
-			{slot: 4, x: 1250 + 225 - 200, y: 720},
-		]
-		for (let slt of offsets) {
-			let slot = slt.slot;
-			DrawButtonKDEx("slot_" + slot + "prev", () => {
-				KDSaveSlot = slot;
-				return true;
-			}, true,
-			((danger && (slot == KDSaveSlot)) ? (Math.random() > 0.5 ? -1 : 1) : 0) + slt.x,
-			((danger && (slot == KDSaveSlot)) ? (Math.random() > 0.5 ? -1 : 1) : 0) + slt.y,
-			400, 50, (loadedsaveNames[slot-1] ? loadedsaveNames[slot - 1] : "")
-				|| (TextGet("KDEmpty")),
-			(danger && (slot == KDSaveSlot)) ? "#ff5277" : "#ffffff", "", undefined, undefined,
-			true, KDButtonColor);
+		// draw 8 slots with names if they're already occupied
+		const xOffsets = [1250 - 225 - 200, 1250 + 225 - 200]; // first and second column pixel offset from left
+		const startY = 550, cols = 2, rows = 4;
+		// if slots 0-8 selected it's +0, then 9-16 it's +8...
+		let pageSlotOffset = Math.floor((KDSaveSlot - 1)/(cols*rows)) * (cols*rows);
+		const dangerColor = "#ff5277", defaultColor = "#ffffff", selectedColor = "#00ff00";
+		for(let col = 0; col < cols; col++) {
+			for(let row = 0; row < rows; row++) {
+				let slot = row*cols + col + pageSlotOffset + 1;
+				let yOffset = startY + row*70;
+				let slotText = slot + ". " + ((loadedsaveNames[slot-1] ? loadedsaveNames[slot - 1] : "") || TextGet("KDEmpty"));
+				let textColor = (danger && (slot == KDSaveSlot)) ? dangerColor : (slot == KDSaveSlot ? selectedColor : defaultColor);
+				DrawButtonKDEx("slot_" + slot + "prev", () => { // on click change save slot
+					KDSaveSlot = slot;
+					return true;
+				}, true,
+				((danger && (slot == KDSaveSlot)) ? (Math.random() > 0.5 ? -1 : 1) : 0) + xOffsets[col % 2],
+				((danger && (slot == KDSaveSlot)) ? (Math.random() > 0.5 ? -1 : 1) : 0) + yOffset,
+				400, 50, slotText, textColor, "", undefined, undefined,
+				true, KDButtonColor);
+			}
 		}
 
 		DrawButtonKDEx("selectName", () => {

--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -2973,6 +2973,8 @@ function KinkyDungeonRun() {
 		DrawButtonKDEx(`SaveButtonL`, (_bdata) => {
 			if (KDSaveSlot > 1) {
 				KDSaveSlot--;
+			} else {
+				KDSaveSlot = (saveSlotsPerPage*maxSaveSlotPages);
 			}
 			KDConfirmDeleteSave = false;
 			return true;
@@ -2984,6 +2986,8 @@ function KinkyDungeonRun() {
 		DrawButtonKDEx(`SaveButton4`, (_bdata) => {
 			if (KDSaveSlot < (saveSlotsPerPage*maxSaveSlotPages)) {
 				KDSaveSlot++;
+			} else {
+				KDSaveSlot = 1;
 			}
 			KDConfirmDeleteSave = false;
 			return true;

--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -33,7 +33,9 @@ let KDVeryFastWaitTime = 10;
 let KDNormalWaitTime = 500;
 let KDSlowWaitTime = 1500;
 
-let maxSaveSlots = 4;
+let saveSlotsPerPage = 4; // number of save slots, we have space for 4 on the UI
+let maxSaveSlotPages = 4; // number of pages of saves we allow
+let currentSavePage = 0; // which page are we on
 
 let KDFullscreen = false;
 let KDExitButton = false;
@@ -1069,7 +1071,7 @@ function KDSaveToggles() {
 
 async function KDMigrateSaveToNewSystem() {
 	// Refresh saves
-	for (var i = 1; i < 5; i++) {
+	for (var i = 1; i <= (maxSaveSlotPages*saveSlotsPerPage); i++) {
 		let num = (i);
 		await KinkyDungeonDBLoad(num).then((code) => {
 			loadedsaveslots[num - 1] = code;
@@ -1560,7 +1562,7 @@ function KinkyDungeonLoad(): void {
 				localStorage.setItem('KDLastSaveSlot', "1");
 				KDMigrateSaveToNewSystem();
 			} else {
-				for (var i = 1; i < 5; i++) {
+				for (var i = 1; i <= (saveSlotsPerPage*maxSaveSlotPages); i++) {
 					let num = (i);
 					KinkyDungeonDBLoad(num).then((code) => {
 						loadedsaveslots[num - 1] = code;
@@ -2078,7 +2080,7 @@ function KinkyDungeonRun() {
 				KinkyDungeonState = "Name";
 				KDSaveSlot = (localStorage.getItem('KDLastSaveSlot') !== null) ? parseInt(localStorage.getItem('KDLastSaveSlot')) : 4;
 				let emptySlot = undefined;
-				for (var i = 1; i < 5; i++) {
+				for (var i = 1; i <= (saveSlotsPerPage*maxSaveSlotPages); i++) {
 					let num = (i);
 					KinkyDungeonDBLoad(num).then((code) => {
 						loadedsaveslots[num - 1] = code;
@@ -2104,7 +2106,7 @@ function KinkyDungeonRun() {
 				KinkyDungeonDBLoad(0).then((code) => {
 					KDSlot0 = code;
 				});
-				for (var i = 1; i < 5; i++) {
+				for (var i = 1; i <= (saveSlotsPerPage*maxSaveSlotPages); i++) {
 					let num = (i);
 					KinkyDungeonDBLoad(num).then((code) => {
 						loadedsaveslots[num - 1] = code;
@@ -2980,7 +2982,7 @@ function KinkyDungeonRun() {
 		DrawTextFitKD(`${KDSaveSlot}`, 1430, 385, 360, "#ffffff", undefined, 30);
 		// Right to increment
 		DrawButtonKDEx(`SaveButton4`, (_bdata) => {
-			if (KDSaveSlot < maxSaveSlots) {
+			if (KDSaveSlot < (saveSlotsPerPage*maxSaveSlotPages)) {
 				KDSaveSlot++;
 			}
 			KDConfirmDeleteSave = false;
@@ -4728,7 +4730,7 @@ let LoadMenuCurrentSlot: number;
 let loadedsaveslots: string[] = [];
 let loadedcloudsaveslots: string[] = [];
 let loadedsaveNames: string[] = [];
-for (let i = 0; i < maxSaveSlots; i++) {
+for (let i = 0; i < (saveSlotsPerPage*maxSaveSlotPages); i++) {
 	loadedsaveslots.push(null);
 	loadedsaveNames.push("");
 }
@@ -4760,6 +4762,9 @@ function KDDrawLoadMenu() {
 	YY = YYstart + 50;
 	YYd = 80;
 	let CombarXX = 520;
+	let saveSlotXOffset = 100;
+	let saveSlotWidth = 300;
+	let slotPageBtnWidth = 64;
 	// Save slots buttons
 	DrawTextFitKD(TextGet("PlayGameWithCurrentCode"), 1250, YYstart - 70, 1000, "#ffffff", undefined, 40);
 	if (KDENABLEDISCORDSYNC) {
@@ -4778,7 +4783,26 @@ function KDDrawLoadMenu() {
 	}
 
 	if (!KDLoadCloudGames) {
-		for (let i = 1; i < 5; i++) {
+		// Left button to switch to previous page
+		DrawButtonKDEx(`PreviousPage`, (_bdata) => {
+			// when on page 0 and going left, wrap over to last page
+			currentSavePage = (currentSavePage - 1) < 0 ? maxSaveSlotPages - 1 : currentSavePage - 1;
+			return true;
+		}, true, CombarXX + saveSlotXOffset + (saveSlotWidth/2) - slotPageBtnWidth - 35, YYstart - 20, slotPageBtnWidth, slotPageBtnWidth, '<', "#ffffff");
+		// page number / max pages displayed as text
+		DrawTextFitKD(`${currentSavePage + 1}/${maxSaveSlotPages}`,
+			CombarXX + saveSlotXOffset + (saveSlotWidth/2), YYstart+10, 80, "#ffffff", undefined, 35
+		);
+		// Right button to switch to next page
+		DrawButtonKDEx(`NextPage`, (_bdata) => {
+			// when on last page and going right, wrap to 0th page
+			currentSavePage = (currentSavePage + 1) % maxSaveSlotPages;
+			return true;
+		}, true, CombarXX + saveSlotXOffset + (saveSlotWidth/2) + 35, YYstart - 20, slotPageBtnWidth, slotPageBtnWidth, '>', "#ffffff");
+
+		let startSaveSlot = currentSavePage*saveSlotsPerPage + 1;
+		let endSaveSlot = startSaveSlot + saveSlotsPerPage;
+		for (let i = startSaveSlot; i < endSaveSlot; i++) {
 			let num = (i);
 			// Slot button
 			DrawButtonKDEx(TextGet("KDSaveSlotButton") + num, () => {
@@ -4801,7 +4825,7 @@ function KDDrawLoadMenu() {
 
 
 				return true;
-			}, true, CombarXX + 100, YY, 300, 64, TextGet("KDSaveSlotButton") + i, "#ffffff", "");
+			}, true, CombarXX + saveSlotXOffset, YY, saveSlotWidth, 64, TextGet("KDSaveSlotButton") + i, "#ffffff", "");
 			// Selected arrow if the currently selected slot matches
 			if (num == LoadMenuCurrentSlot) {
 				DrawTextFitKD(`<--`, CombarXX + 430, YY + 35, 50, "#ffffff", undefined, 40);

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After installation run `npm i && npm run build` in the root folder of the projec
 
 OR if you have Docker you can use Node's docker image to do the building for you. In the root folder run
 ```bash
-docker run --rm --name kdbuilder -v "$PWD":/usr/src/app -w /usr/src/app node:20-slim bash -c 'npm install && npm run build'
+docker run --rm --name kdbuilder -v "$PWD":/usr/src/app -w /usr/src/app node:23-slim bash -c 'npm i && npm run build'
 ```
 
 When you are developing the game you might want to run compilation each time you modify a file (so you do not have to switch to the terminal screen to run `npm run build` by hand). The `npm run buildCont` command does this for you. If you want the same with docker use the following:
@@ -51,7 +51,7 @@ docker run --rm -it --name kdbuilder -v "$PWD":/usr/src/app -w /usr/src/app node
 ## Run
 You can start the server with the `npm run serve` command, or with docker:
 ```bash
-docker run --rm --name kdbuilder -v "$PWD":/usr/src/app -w /usr/src/app -p 8080:8080 node:20-slim npm run serve
+docker run --rm -it --name kdrunner -v "$PWD":/usr/src/app -w /usr/src/app -p 8080:8080 node:23-slim npm run serve
 ```
 
 Afterwards open http://localhost:8080 in your browser of choice. Press ctrl+c in the terminal to stop the server when you are done.


### PR DESCRIPTION
Add pages of save slots, like this:
![savepages](https://github.com/user-attachments/assets/75696c78-3c15-4ef2-961b-7005bd8441d5)
There is an ongoing discussion on discord about save file sizes, but I understood most opinions to be "better to have more than not have it at all", you can merge if you think it is fine.

I've looked at the code for cloud sync and it seems to only look at slots 0 and 1, and use negative indexes when loading them(?) so I don't think adding more pages would interfere with that functionality