### PR TITLE
Fix: mimiccurse transformation chance

### DIFF
--- a/Game/src/effect/KinkyDungeonEvents.ts
+++ b/Game/src/effect/KinkyDungeonEvents.ts
@@ -1003,11 +1003,14 @@ let KDEventMapInventory: Record<string, Record<string, (e: KinkyDungeonEvent, it
 				&& KDCurses[KDGetCurse(item)]?.activatecurse)) return;
 			if (_e.time) {
 				let addedTick = KDItemDataQuery(item, "mimiccurse") || 0;
-				if (!addedTick)
+				if (!addedTick) {
 					KDItemDataSet(item, "mimiccurse", KinkyDungeonCurrentTick);
-				if (!addedTick || KinkyDungeonCurrentTick - addedTick < _e.time) return;
+					return;
+				}
+				let elapsedTime = KinkyDungeonCurrentTick - addedTick;
+				if (elapsedTime % (_e.time + elapsedTime/4) !== 0) return;
 			}
-			if ((KDRandom() < _e.chance || 0.1)) {
+			if ((KDRandom() < (_e.chance || 0.1))) {
 				if (item) {
 					let tags = _e.tags || KDGetCursedTags(item);
 					let lock = item.lock || "Purple";

--- a/Game/src/effect/KinkyDungeonEvents.ts
+++ b/Game/src/effect/KinkyDungeonEvents.ts
@@ -1008,7 +1008,7 @@ let KDEventMapInventory: Record<string, Record<string, (e: KinkyDungeonEvent, it
 					return;
 				}
 				let elapsedTime = KinkyDungeonCurrentTick - addedTick;
-				if (elapsedTime % (_e.time + elapsedTime/4) !== 0) return;
+				if (elapsedTime % (_e.time + elapsedTime/11) !== 0) return;
 			}
 			if ((KDRandom() < (_e.chance || 0.1))) {
 				if (item) {


### PR DESCRIPTION
In the original version the transformation occurred in 100% of the cases just after the time had elapsed, which was probably not the intention. In this version, the transformation attempt reflects probability and is performed only 7 times instead of infinitely. The attempts are non-linearly distributed from the initial time to time +120 (for _e.time = 10)