### PR TITLE
Item's original event missing when using KDMorphToInventoryVariant()

### DIFF
--- a/Game/src/item/KinkyDungeonInventory.ts
+++ b/Game/src/item/KinkyDungeonInventory.ts
@@ -3083,7 +3083,7 @@ function KDMorphToInventoryVariant(item: item, variant: KDRestraintVariant, pref
 	if (!KinkyDungeonRestraintVariants[newname])
 		KinkyDungeonRestraintVariants[newname] = variant;
 	if (variant.events)
-		Object.assign(events, variant.events);
+		events.push(...variant.events);
 	KDUpdateItemEventCache = true;
 	KDChangeItemName(item, item.type, variant.template);
 	if (item.type == LooseRestraint) {


### PR DESCRIPTION
Item's original event missing when using KDMorphToInventoryVariant().
Events of origRestraint get replaced with enchant & hex events, should append new events to existing array, instead of using Object.assign().