### PR TITLE
Fix crotch rope false update under dynamic link

### DIFF
--- a/Game/src/player/KinkyDungeonStats.ts
+++ b/Game/src/player/KinkyDungeonStats.ts
@@ -1770,19 +1770,18 @@ function KinkyDungeonUpdateStats(delta: number): void {
 	let drains = [];
 
 
-	for (let item of KinkyDungeonFullInventory()) {
-		if (item.type == Restraint) {
-			if (KDRestraint(item).difficultyBonus) {
-				KinkyDungeonDifficulty += KDRestraint(item).difficultyBonus;
+	for (let pair of KinkyDungeonAllRestraintDynamic()) {
+		let item = pair.item;
+		if (KDRestraint(item).difficultyBonus) {
+			KinkyDungeonDifficulty += KDRestraint(item).difficultyBonus;
+		}
+		if (KDRestraint(item).crotchrope) KinkyDungeonHasCrotchRope = true;
+		if (KDRestraint(item).enchantedDrain) {
+			if (KDGameData.AncientEnergyLevel > 0) {
+				//maxDrain = Math.max(maxDrain, KDRestraint(item).enchantedDrain);
+				drains.push(KDRestraint(item).enchantedDrain);
 			}
-			if (KDRestraint(item).crotchrope) KinkyDungeonHasCrotchRope = true;
-			if (KDRestraint(item).enchantedDrain) {
-				if (KDGameData.AncientEnergyLevel > 0) {
-					//maxDrain = Math.max(maxDrain, KDRestraint(item).enchantedDrain);
-					drains.push(KDRestraint(item).enchantedDrain);
-				}
-				//KDGameData.AncientEnergyLevel = Math.max(0, KDGameData.AncientEnergyLevel - KDRestraint(item).enchantedDrain * delta);
-			}
+			//KDGameData.AncientEnergyLevel = Math.max(0, KDGameData.AncientEnergyLevel - KDRestraint(item).enchantedDrain * delta);
 		}
 	}
 	if (drains.length > 0 && delta > 0) {


### PR DESCRIPTION
The problem:
`KinkyDungeonUpdateStats()`, where updating `KinkyDungeonHasCrotchRope`, is using `KinkyDungeonFullInventory()` to iterate through all worn restraints, which ignores dynamic linked ones. 

This causes:
1. crotch rope worn under chastity belt not updating `KinkyDungeonHasCrotchRope` to `true`;
2. potentially causes ancient restraints not draining ancient energy when worn under others;
3. potentially causes Fuuka's collar not adding `difficultyBonus` when worn under others.

The fix:
Replacing `KinkyDungeonFullInventory()` with `KinkyDungeonAllRestraintDynamic()`.