### PR TITLE
Headpats!

### DIFF
--- a/Data/Defs.ts
+++ b/Data/Defs.ts
@@ -2092,6 +2092,12 @@ let Hardpoints: Record<string, Hardpoint> = {
 		Y: 690,
 		Angle: 0,
 	},
+	HeadpatHead: {
+        Parent: "Head",
+        X: 1220,
+        Y: 360,
+        Angle: 0,
+    },
 	Rear: {
 		Parent: "Torso",
 		X: 1127,

--- a/Game/src/base/KDTypeDefs.ts
+++ b/Game/src/base/KDTypeDefs.ts
@@ -3096,6 +3096,7 @@ interface KDMapDataType {
 	JailFaction: string[],
 	GuardFaction: string[],
 	MapFaction: string,
+	clickHeadpatted: boolean
 }
 
 

--- a/Game/src/base/game/KinkyDungeonGame.ts
+++ b/Game/src/base/game/KinkyDungeonGame.ts
@@ -251,6 +251,8 @@ function KDDefaultMapData(mapX: number, mapY: number, RoomType: string = "", Map
 		QuestsAccepted: 0,
 		KeyQuota: -1,
 		KeysHeld: 0,
+
+		clickHeadpatted: false
 	};
 }
 

--- a/Game/src/effect/KinkyDungeonEvents.ts
+++ b/Game/src/effect/KinkyDungeonEvents.ts
@@ -12418,6 +12418,18 @@ let KDEventMapGeneric: Record<string, Record<string, (e: string, data: any) => v
 	},
 	"afterModConfig": {
 		// Ran after returning to menu from the mod configuration window.
+	},
+	"afterDress": {
+		"clickHeadPat": (_e, data) => {
+			const id = "kinky-dungeon-headpat-modal";
+			if ((KinkyDungeonState == 'Game') && (KinkyDungeonDrawState == 'Game')) {
+				KinkyDungeonHeadpatModal()
+			}
+			else if (document.querySelector(`#${id}`)) {
+				let el = document.getElementById(id);
+				el.parentNode.removeChild(el);
+			}
+		}
 	}
 };
 

--- a/Game/src/player/KDExpressions.ts
+++ b/Game/src/player/KDExpressions.ts
@@ -287,6 +287,25 @@ let KDExpressions: Record<string, KDExpression> = {
 			};
 		},
 	},
+	"ClickHeadpat": {
+		priority: 1.5,
+		criteria: (C, flags) => {
+			if (flags.get("clickheadpatted_recently")) {
+				return true;
+			}
+			return false;
+		},
+		expression: (C, flags) => {
+			return {
+				EyesPose: "EyesClosed",
+				Eyes2Pose: "",
+				BrowsPose: "",
+				Brows2Pose: "",
+				BlushPose: "",
+				MouthPose: "MouthSmile",
+			};
+		},
+	},
 	"Spank": {
 		priority: 14,
 		criteria: (C, flags) => {

--- a/Game/src/player/KinkyDungeonDress.ts
+++ b/Game/src/player/KinkyDungeonDress.ts
@@ -1045,3 +1045,48 @@ function KDGetFactionFilters(faction: string): Record<string, LayerFilter> {
 		return KinkyDungeonFactionFilters[KDFactionProperties[faction]?.jailAlliedFaction];
 	return undefined;
 }
+
+/**
+ * 
+ */
+function KinkyDungeonHeadpatModal() {
+    const id = "kinky-dungeon-headpat-modal";
+    if (document.querySelector(`#${id}`)) {
+        let el = document.getElementById(id);
+        el.parentNode.removeChild(el);
+    }
+    const backdrop = document.createElement("div");
+    backdrop.id = id;
+    let pxassign = {
+        position: "absolute",
+        width: "200px",
+        height: "100px",
+		top: "0px",
+		left: "0px",
+		transform: "none",
+        //backgroundColor: "#ffffff"
+    }
+    let hardpointlocs = GetHardpointLoc(KinkyDungeonPlayer, 0, 0, 1, "HeadpatHead", KDToggles.FlipPlayer)
+    console.log(hardpointlocs)
+    pxassign.top = `${(hardpointlocs.y - (KDIsHogtied() ? 100 : 50))}px`;
+    pxassign.left = `${(hardpointlocs.x - (KDIsHogtied() ? 100 : 100))}px`;
+    pxassign.transform = `rotate(${hardpointlocs.angle}rad)`
+    console.log(pxassign)
+    Object.assign(backdrop.style, pxassign);
+    backdrop.addEventListener("click", () => {
+        console.log("Headpats!")
+        if ((KinkyDungeonState == 'Game') && (KinkyDungeonDrawState == 'Game')) {
+            KinkyDungeonSetFlag("clickheadpatted_recently", 5);
+            if (!KDMapData.clickHeadpatted) {
+                KDMapData.clickHeadpatted = true;
+                KDChangeWill("","","",0.5)
+                KinkyDungeonSendTextMessage(4, TextGet("KDClickedHeadpat"), "#ffffff", 4)
+            }
+            else {
+                KinkyDungeonSendTextMessage(4, TextGet("KDClickedHeadpatNoWill"), "#ffffff", 4)
+            }
+            KinkyDungeonAdvanceTime(1, true, true)
+        }
+    });
+    document.body.appendChild(backdrop);
+}

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -31974,3 +31974,6 @@ KDCantDrop,You can't drop that
 
 KDTugWaistRestraints,"You tug against your waist chains, but your arms can't reach far enough."
 KDTugYoke,"The yoke you are wearing prevents you from reaching that!"
+
+KDClickedHeadpat,"Your headpatting restored your willpower slightly!"
+KDClickedHeadpatNoWill,"Your headpatting feels nice!"


### PR DESCRIPTION
Implements a modal that will get drawn whenever the afterDress event is called. When clicked while in the game, it will give a text message, with a different one the first time it happens in a given map to give the player 5 WP. Uses hardpoints to ensure it follows the player while kneeling and hogtying. 