### PR TITLE
Cleanup use of squared Euclidean distances.

### DIFF
--- a/Game/src/effect/KinkyDungeonEvents.ts
+++ b/Game/src/effect/KinkyDungeonEvents.ts
@@ -9184,24 +9184,24 @@ let KDEventMapBullet: Record<string, Record<string, (e: KinkyDungeonEvent, b: KD
 			if (enemy.attackPoints > 0) return;
 			let target = null;
 			if (b.bullet.faction) {
-				let minDist = 1000000;
+				let minDistSQ = 1000*1000;
 				let entity = null;
-				let playerDist = 1000000;
+				let playerDistSQ = 1000*1000;
 				if (KDFactionHostile(b.bullet.faction, "Player")) {
-					playerDist = KDistEuclideanSquared(KinkyDungeonPlayerEntity.x - b.bullet.targetX, KinkyDungeonPlayerEntity.y - b.bullet.targetY);
-					if (playerDist <= e.aoe*e.aoe) {
+					playerDistSQ = KDistEuclideanSquared(KinkyDungeonPlayerEntity.x - b.bullet.targetX, KinkyDungeonPlayerEntity.y - b.bullet.targetY);
+					if (playerDistSQ <= e.aoe*e.aoe) {
 						entity = KinkyDungeonPlayerEntity;
-						minDist = playerDist;
+						minDistSQ = playerDistSQ;
 					}
 				}
 
 				let enemies = KDNearbyEnemies(b.bullet.targetX, b.bullet.targetY, e.aoe);
 				for (let en of enemies) {
 					if (!KDHelpless(en) && KDFactionHostile(b.bullet.faction, en)) {
-						playerDist = KDistEuclideanSquared(en.x - b.bullet.targetX, en.y - b.bullet.targetY);
-						if (playerDist < minDist) {
+						playerDistSQ = KDistEuclideanSquared(en.x - b.bullet.targetX, en.y - b.bullet.targetY);
+						if (playerDistSQ < minDistSQ) {
 							entity = en;
-							minDist = playerDist;
+							minDistSQ = playerDistSQ;
 						}
 					}
 				}
@@ -9214,14 +9214,15 @@ let KDEventMapBullet: Record<string, Record<string, (e: KinkyDungeonEvent, b: KD
 
 			let bullets = KDMapData.Bullets.filter((bb) => { return bb.bullet?.spell?.name == "ShadowShroud"; });
 			let nearest = null;
-			let nearestDist = 10000;
+			let nearestDistSQ = 100*100;
 			for (let bb of bullets) {
 				if (KinkyDungeonMovableTilesEnemy.includes(KinkyDungeonMapGet(bb.x, bb.y))) {
-					let dist = KDistEuclideanSquared(b.x - bb.x, b.y - bb.y);
-					let distplayer = KDistEuclideanSquared(target.x - bb.x, target.y - bb.y);
-					if (dist <= e.aoe*e.aoe && distplayer < nearestDist
-						&& distplayer < KDistEuclideanSquared(target.x - enemy.x, target.y - enemy.y)) {
-						nearestDist = distplayer;
+					let distSQ = KDistEuclideanSquared(b.x - bb.x, b.y - bb.y);
+					let distplayerSQ = KDistEuclideanSquared(target.x - bb.x, target.y - bb.y);
+					if (distSQ <= e.aoe*e.aoe && distplayerSQ < nearestDistSQ
+						&& distplayerSQ < KDistEuclideanSquared(target.x - enemy.x, target.y - enemy.y))
+					{
+						nearestDistSQ = distplayerSQ;
 						nearest = bb;
 					}
 				}
@@ -9252,24 +9253,24 @@ let KDEventMapBullet: Record<string, Record<string, (e: KinkyDungeonEvent, b: KD
 			if (enemy.attackPoints > 0) return;
 			let target = null;
 			if (b.bullet.faction) {
-				let minDist = 1000000;
+				let minDistSQ = 1000*1000;
 				let entity = null;
-				let playerDist = 1000000;
+				let playerDistSQ = 1000*1000;
 				if (KDFactionHostile(b.bullet.faction, "Player")) {
-					playerDist = KDistEuclideanSquared(KinkyDungeonPlayerEntity.x - b.bullet.targetX, KinkyDungeonPlayerEntity.y - b.bullet.targetY);
-					if (playerDist <= e.aoe*e.aoe) {
+					playerDistSQ = KDistEuclideanSquared(KinkyDungeonPlayerEntity.x - b.bullet.targetX, KinkyDungeonPlayerEntity.y - b.bullet.targetY);
+					if (playerDistSQ <= e.aoe*e.aoe) {
 						entity = KinkyDungeonPlayerEntity;
-						minDist = playerDist;
+						minDistSQ = playerDistSQ;
 					}
 				}
 
 				let enemies = KDNearbyEnemies(b.bullet.targetX, b.bullet.targetY, e.aoe);
 				for (let en of enemies) {
 					if (!KDHelpless(en) && KDFactionHostile(b.bullet.faction, en)) {
-						playerDist = KDistEuclideanSquared(en.x - b.bullet.targetX, en.y - b.bullet.targetY);
-						if (playerDist < minDist) {
+						playerDistSQ = KDistEuclideanSquared(en.x - b.bullet.targetX, en.y - b.bullet.targetY);
+						if (playerDistSQ < minDistSQ) {
 							entity = en;
-							minDist = playerDist;
+							minDistSQ = playerDistSQ;
 						}
 					}
 				}
@@ -9657,24 +9658,24 @@ let KDEventMapBullet: Record<string, Record<string, (e: KinkyDungeonEvent, b: KD
 			if (data.delta > 0 && b.bullet.targetX != undefined && b.bullet.targetY != undefined) {
 				// Scan for targets near the target location
 				if (b.bullet.faction && !(e.kind == "dumb")) {
-					let minDist = 1000000;
+					let minDistSQ = 1000*1000;
 					let entity = null;
-					let playerDist = 1000000;
+					let playerDistSQ = 1000*1000;
 					if (KDFactionHostile(b.bullet.faction, "Player")) {
-						playerDist = KDistEuclideanSquared(KDPlayer().x - b.bullet.targetX, KDPlayer().y - b.bullet.targetY);
-						if (playerDist <= e.dist * e.dist) {
+						playerDistSQ = KDistEuclideanSquared(KDPlayer().x - b.bullet.targetX, KDPlayer().y - b.bullet.targetY);
+						if (playerDistSQ <= e.dist * e.dist) {
 							entity = KDPlayer();
-							minDist = playerDist;
+							minDistSQ = playerDistSQ;
 						}
 					}
 
 					let enemies = KDNearbyEnemies(b.bullet.targetX, b.bullet.targetY, e.dist);
 					for (let en of enemies) {
 						if (!KDHelpless(en) && KDFactionHostile(b.bullet.faction, en)) {
-							playerDist = KDistEuclideanSquared(en.x - b.bullet.targetX, en.y - b.bullet.targetY);
-							if (playerDist < minDist) {
+							playerDistSQ = KDistEuclideanSquared(en.x - b.bullet.targetX, en.y - b.bullet.targetY);
+							if (playerDistSQ < minDistSQ) {
 								entity = en;
-								minDist = playerDist;
+								minDistSQ = playerDistSQ;
 							}
 						}
 					}

--- a/Game/src/enemy/KDAIList.ts
+++ b/Game/src/enemy/KDAIList.ts
@@ -76,16 +76,16 @@ let KDAIType: Record<string, AIType> = {
 					ex = aiData.master.x;
 					ey = aiData.master.y;
 				} else if (KDRandom() < cohesion) {
-					let minDist = (enemy.Enemy.cohesionRange ? enemy.Enemy.cohesionRange : aiData.visionRadius);
-					minDist *= minDist; // squared is much faster than KDistEuclidean
+					let minDistSQ = (enemy.Enemy.cohesionRange ? enemy.Enemy.cohesionRange : aiData.visionRadius);
+					minDistSQ *= minDistSQ; // squared is much faster than KDistEuclidean
 					for (let e of KDMapData.Entities) {
 						if (e == enemy) continue;
 						if (['guard', 'ambush'].includes(KDGetAI(enemy))) continue;
 						if (enemy.Enemy.clusterWith && !e.Enemy.tags[enemy.Enemy.clusterWith]) continue;
 						if (KinkyDungeonTilesGet(e.x + "," + e.y) && KinkyDungeonTilesGet(e.x + "," + e.y).OL) continue;
-						let dist = KDistEuclideanSquared(e.x - enemy.x, e.y - enemy.y);
-						if (dist < minDist) {
-							minDist = dist;
+						let distSQ = KDistEuclideanSquared(e.x - enemy.x, e.y - enemy.y);
+						if (distSQ < minDistSQ) {
+							minDistSQ = distSQ;
 							let ePoint = KinkyDungeonGetNearbyPoint(ex, ey, false);
 							if (ePoint) {
 								ex = ePoint.x;

--- a/Game/src/enemy/KinkyDungeonEnemies.ts
+++ b/Game/src/enemy/KinkyDungeonEnemies.ts
@@ -6095,7 +6095,7 @@ function KinkyDungeonEnemyLoop(enemy: entity, player: any, delta: number, vision
 											} else if (KDRandom() < cohesion) {
 												let minDist = enemy.Enemy.cohesionRange ? enemy.Enemy.cohesionRange : AIData.visionRadius;
 												let ent = KDNearbyEnemies(enemy.x, enemy.y, minDist);
-												minDist *= minDist;
+												let minDistSQ = minDist * minDist;
 												for (let e of ent) {
 													if (e == enemy) continue;
 													if (['guard', 'ambush', 'looseguard'].includes(KDGetAI(enemy))) continue;
@@ -6106,9 +6106,9 @@ function KinkyDungeonEnemyLoop(enemy: entity, player: any, delta: number, vision
 													)) continue;
 													if (KDGetFaction(e) != KDGetFaction(enemy)) continue;
 													if (KinkyDungeonTilesGet(e.x + "," + e.y) && KinkyDungeonTilesGet(e.x + "," + e.y).OL) continue;
-													let dist = KDistEuclideanSquared(e.x - enemy.x, e.y - enemy.y);
-													if (dist < minDist) {
-														minDist = dist;
+													let distSQ = KDistEuclideanSquared(e.x - enemy.x, e.y - enemy.y);
+													if (distSQ < minDistSQ) {
+														minDistSQ = distSQ;
 														let ePoint = KinkyDungeonGetNearbyPoint(ex, ey, false);
 														if (ePoint) {
 															ex = ePoint.x;

--- a/Game/src/restraint/KDTethers.ts
+++ b/Game/src/restraint/KDTethers.ts
@@ -380,15 +380,16 @@ function KinkyDungeonUpdateTether(delta: number, Msg: boolean, Entity: entity, x
 				}
 
 				if (!slot) {
-					let mindist = playerDist*playerDist;
+					let mindistSQ = playerDist*playerDist;
 					for (let X = Entity.x-1; X <= Entity.x+1; X++) {
 						for (let Y = Entity.y-1; Y <= Entity.y+1; Y++) {
 							if ((X !=  Entity.x || Y != Entity.y)
 								&& KinkyDungeonMovableTilesEnemy.includes(KinkyDungeonMapGet(X, Y))
-								&& KDistEuclideanSquared(X-leash.x, Y-leash.y) < mindist
+								&& KDistEuclideanSquared(X-leash.x, Y-leash.y) < mindistSQ
 								&& !(KinkyDungeonEntityAt(X-leash.x, Y-leash.y)
-								&& KDIsImmobile(KinkyDungeonEntityAt(X-leash.x, Y-leash.y), true))) {
-								mindist = KDistEuclideanSquared(X-leash.x, Y-leash.y);
+								&& KDIsImmobile(KinkyDungeonEntityAt(X-leash.x, Y-leash.y), true)))
+							{
+								mindistSQ = KDistEuclideanSquared(X-leash.x, Y-leash.y);
 								slot = {x:X, y:Y};
 							}
 						}
@@ -404,14 +405,15 @@ function KinkyDungeonUpdateTether(delta: number, Msg: boolean, Entity: entity, x
 					let enemy = KinkyDungeonEntityAt(slot.x, slot.y);
 					if (enemy && !enemy.player) { //  && !KDHostile(Entity, enemy)
 						let slot2 = null;
-						let mindist2 = playerDist*playerDist;
+						let mindistSQ2 = playerDist*playerDist;
 						for (let X = enemy.x-1; X <= enemy.x+1; X++) {
 							for (let Y = enemy.y-1; Y <= enemy.y+1; Y++) {
 								if ((X !=  enemy.x || Y != enemy.y)
 									&& !KinkyDungeonEntityAt(X, Y)
 									&& KinkyDungeonMovableTilesEnemy.includes(KinkyDungeonMapGet(X, Y))
-									&& KDistEuclideanSquared(X-Entity.x, Y-Entity.y) < mindist2) {
-									mindist2 = KDistEuclideanSquared(X-Entity.x, Y-Entity.y);
+									&& KDistEuclideanSquared(X-Entity.x, Y-Entity.y) < mindistSQ2)
+								{
+									mindistSQ2 = KDistEuclideanSquared(X-Entity.x, Y-Entity.y);
 									slot2 = {x:X, y:Y};
 								}
 							}


### PR DESCRIPTION
In some places, distances between two points are calcuated using KDistEuclidean(), which involves a square root.  For those instances where we don't care about actual distance, but simply want to know if it's closer/further away than something else, the square root is not necessary.  Hence, KDistEuclideanSquared().

It is important to keep the usage of these values separate, so that squared distances aren't intermixed with linear distances.  Typescript isn't powerful enough to let us create opaque types that will let the type system prevent the use of mismatched numeric spaces.

Append 'SQ' to all variables containing squared distances.  Ensure all uses of squared distances aren't mixed with linear distances, or used where linear distances are expected, and vice-versa.  Highly imperfect, but better than nothing.