### PR TITLE
Add popups to allow copying wardrobe colors and properties for NPC outfits

### DIFF
--- a/Game/src/player/KDWardrobe.ts
+++ b/Game/src/player/KDWardrobe.ts
@@ -365,19 +365,6 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 				return true;
 			}, true, X, YY - 40, width/2 - 10, 30, TextGet("KDPasteLayer"), KDBaseWhite);
 		} else {
-			if (TestMode) {
-				DrawButtonKDEx("ExportAllProps", (_bdata) => {
-					if (Model.Properties) {
-						KDExportWardrobeDataToClipboardOrModal(JSON.stringify(Model.Properties), "All Layers Props");
-					}
-					return true;
-				}, true, X + width/2 + 10, YY - 40, width/2 - 10, 30, TextGet("KDExportAllProps"), KDBaseMint);
-
-				DrawButtonKDEx("KDCopyProps", (_bdata) => {
-					KDExportWardrobeDataToClipboardOrModal(JSON.stringify(Properties), "Layer Props");
-					return true;
-				}, true, X, YY, width/2 - 10, 30, TextGet("KDCopyLayer"), KDBaseWhite);
-			}
 			let CF = KDTextField("KDCopyProperties", X, YY - 70,
 				width, 30, undefined, undefined, "300", 12);
 			if (CF.Created) {
@@ -411,6 +398,18 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 				};
 			}
 		}
+		if (TestMode)
+			DrawButtonKDEx("ExportAllProps", (_bdata) => {
+				if (Model.Properties) {
+					KDExportWardrobeDataToClipboardOrModal(JSON.stringify(Model.Properties), "All Layers Props");
+				}
+				return true;
+			}, true, X + width/2 + 10, YY - 40, width/2 - 10, 30, TextGet("KDExportAllProps"), KDBaseMint);
+
+		DrawButtonKDEx("KDCopyProps", (_bdata) => {
+			KDExportWardrobeDataToClipboardOrModal(JSON.stringify(Properties), "Layer Props");
+			return true;
+		}, true, X, YY, width/2 - 10, 30, TextGet("KDCopyLayer"), KDBaseWhite);
 		YY += 60;
 
 		/** Property fields */
@@ -515,8 +514,8 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 
 
 
+
 		if (!KDClipboardDisabled) {
-			if (TestMode)
 			DrawButtonKDEx("KDPasteLayer", (_bdata) => {
 				navigator.clipboard.readText()
 					.then(text => {
@@ -532,19 +531,6 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 				return true;
 			}, true, X, YY - 40, width/2 - 10, 30, TextGet("KDPasteLayer"), KDBaseWhite);
 		} else {
-			if (TestMode) {
-				DrawButtonKDEx("ExportAllLayers", (_bdata) => {
-					if (Model.Filters) {
-						KDExportWardrobeDataToClipboardOrModal(JSON.stringify(Model.Filters), "All Layers Colors");
-					}
-					return true;
-				}, true, X + width/2 + 10, YY - 40, width/2 - 10, 30, TextGet("KDExportAllLayers"), KDBaseMint);
-
-				DrawButtonKDEx("KDCopyLayer", (_bdata) => {
-					KDExportWardrobeDataToClipboardOrModal(JSON.stringify(filters), "Copy Layer Colors");
-					return true;
-				}, true, X, YY, width/2 - 10, 30, TextGet("KDCopyLayer"), KDBaseWhite);
-			}
 			let CF = KDTextField("KDCopyFilter", X, YY - 70, width, 30, undefined, undefined, "300");
 			if (CF.Created) {
 				CF.Element.oninput = (_event: any) => {
@@ -574,6 +560,18 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 				};
 			}
 		}
+		if (TestMode)
+			DrawButtonKDEx("ExportAllLayers", (_bdata) => {
+				if (Model.Filters) {
+					KDExportWardrobeDataToClipboardOrModal(JSON.stringify(Model.Filters), "All Layers Colors");
+				}
+				return true;
+			}, true, X + width/2 + 10, YY - 40, width/2 - 10, 30, TextGet("KDExportAllLayers"), KDBaseMint);
+
+		DrawButtonKDEx("KDCopyLayer", (_bdata) => {
+			KDExportWardrobeDataToClipboardOrModal(JSON.stringify(filters), "Copy Layer Colors");
+			return true;
+		}, true, X, YY, width/2 - 10, 30, TextGet("KDCopyLayer"), KDBaseWhite);
 
 
 		YY += 60;

--- a/Game/src/player/KDWardrobe.ts
+++ b/Game/src/player/KDWardrobe.ts
@@ -517,17 +517,6 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 
 		if (!KDClipboardDisabled) {
 			if (TestMode)
-				DrawButtonKDEx("ExportAllLayers", (_bdata) => {
-					if (Model.Filters) {
-						navigator.clipboard.writeText(JSON.stringify(Model.Filters));
-					}
-					return true;
-				}, true, X + width/2 + 10, YY - 40, width/2 - 10, 30, TextGet("KDExportAllLayers"), KDBaseMint);
-
-			DrawButtonKDEx("KDCopyLayer", (_bdata) => {
-				navigator.clipboard.writeText(JSON.stringify(filters));
-				return true;
-			}, true, X, YY, width/2 - 10, 30, TextGet("KDCopyLayer"), KDBaseWhite);
 			DrawButtonKDEx("KDPasteLayer", (_bdata) => {
 				navigator.clipboard.readText()
 					.then(text => {
@@ -543,6 +532,19 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 				return true;
 			}, true, X, YY - 40, width/2 - 10, 30, TextGet("KDPasteLayer"), KDBaseWhite);
 		} else {
+			if (TestMode) {
+				DrawButtonKDEx("ExportAllLayers", (_bdata) => {
+					if (Model.Filters) {
+						KDExportWardrobeDataToClipboardOrModal(JSON.stringify(Model.Filters), "All Layers Colors");
+					}
+					return true;
+				}, true, X + width/2 + 10, YY - 40, width/2 - 10, 30, TextGet("KDExportAllLayers"), KDBaseMint);
+
+				DrawButtonKDEx("KDCopyLayer", (_bdata) => {
+					KDExportWardrobeDataToClipboardOrModal(JSON.stringify(filters), "Copy Layer Colors");
+					return true;
+				}, true, X, YY, width/2 - 10, 30, TextGet("KDCopyLayer"), KDBaseWhite);
+			}
 			let CF = KDTextField("KDCopyFilter", X, YY - 70, width, 30, undefined, undefined, "300");
 			if (CF.Created) {
 				CF.Element.oninput = (_event: any) => {

--- a/Game/src/player/KDWardrobe.ts
+++ b/Game/src/player/KDWardrobe.ts
@@ -1401,6 +1401,113 @@ function KDCanForcePose(C: Character): boolean {
 	return C != KinkyDungeonPlayer;
 }
 
+function KDWardrobeExportPopup(data: string, title: string) {
+	const id = "kinky-dungeon-wardrobe-export";
+	if (document.querySelector(`#${id}`)) {
+		return;
+	}
+	const backdrop = document.createElement("div");
+  backdrop.id = id;
+  Object.assign(backdrop.style, {
+    position: "fixed",
+    inset: 0,
+    backgroundColor: "#000000a0",
+    fontFamily: "'Arial', sans-serif",
+    fontSize: "1.8vmin",
+    lineHeight: 1.6,
+  });
+
+  const modal = document.createElement("div");
+  Object.assign(modal.style, {
+    position: "absolute",
+    display: "flex",
+    flexFlow: "column nowrap",
+    width: "90vw",
+    maxWidth: "1440px",
+    maxHeight: "90vh",
+    overflow: "hidden",
+    backgroundColor: "#282828",
+    color: "#fafafa",
+    left: "50%",
+    top: "50%",
+    transform: "translate(-50%, -50%)",
+    padding: "1rem",
+    borderRadius: "2px",
+    boxShadow: "1px 1px 40px -8px #ffffff80",
+  });
+  backdrop.appendChild(modal);
+
+  const heading = document.createElement("h1");
+  Object.assign(heading.style, {
+    display: "flex",
+    flexFlow: "row nowrap",
+    alignItems: "center",
+    justifyContent: "space-around",
+    textAlign: "center",
+  });
+  heading.appendChild(KinkyDungeonErrorImage("WolfgirlPet"));
+  heading.appendChild(KinkyDungeonErrorImage("Wolfgirl"));
+  heading.appendChild(KinkyDungeonErrorImage("WolfgirlPet"));
+  heading.appendChild(document.createTextNode(HasText(title) ? TextGet(title) : title));
+  heading.appendChild(KinkyDungeonErrorImage("WolfgirlPet"));
+  heading.appendChild(KinkyDungeonErrorImage("Wolfgirl"));
+  heading.appendChild(KinkyDungeonErrorImage("WolfgirlPet"));
+  modal.appendChild(heading);
+
+  const hr = document.createElement("hr");
+  Object.assign(hr.style, {
+    border: `1px solid ${KDBorderColor}`,
+    margin: "0 0 1.5em",
+  });
+  modal.appendChild(hr);
+
+  modal.appendChild(KinkyDungeonErrorPreamble([
+    "Your browser doesn't appear to support exporting directly to the clipboard.\n",
+    "Here's the data for your outfit, for you to copy to your clipboard. Click on the text below and use Control+C to copy it.",
+  ]));
+
+  const pre = document.createElement("pre");
+  Object.assign(pre.style, {
+    flex: 1,
+    backgroundColor: "#1a1a1a",
+    border: "1px solid #ffffff40",
+    fontSize: "1.1em",
+    padding: "1em",
+    userSelect: "all",
+    overflowWrap: "anywhere",
+    overflowX: "hidden",
+    overflowY: "auto",
+    color: KDBorderColor,
+    whiteSpace: "pre-wrap"
+  });
+  pre.textContent = `${data}`;
+  modal.appendChild(pre);
+
+  const buttons = document.createElement("div");
+  Object.assign(buttons.style, {
+    display: "flex",
+    flexFlow: "row wrap",
+    justifyContent: "flex-end",
+    gap: "1em",
+  });
+  modal.appendChild(buttons);
+
+  const closeButton = KinkyDungeonErrorModalButton("Close");
+  closeButton.addEventListener("click", () => {
+    backdrop.remove();
+  });
+  buttons.appendChild(closeButton);
+
+  document.body.appendChild(backdrop);
+}
+function KDExportWardrobeDataToClipboardOrModal(data: string, title: string) {
+	if (!title)
+		title = "Wardrobe Data"
+	if (KDClipboardDisabled)
+		KDWardrobeExportPopup(data, title)
+	else
+		navigator.clipboard.writeText(data)
+}
 function KDDrawWardrobe(_screen: string, Character: Character) {
 	if (KDOutfitInfo.length == 0) KDRefreshOutfitInfo();
 
@@ -1813,7 +1920,7 @@ function KDDrawWardrobe(_screen: string, Character: Character) {
 	}
 
 
-	if (TestMode && !KDClipboardDisabled && C == KinkyDungeonPlayer) {
+	if (TestMode && C == KinkyDungeonPlayer) {
 		DrawButtonKDEx("KDCreateOutfit", (_bdata) => {
 			let exportData = [];
 			if (C?.Appearance)
@@ -1830,7 +1937,7 @@ function KDDrawWardrobe(_screen: string, Character: Character) {
 						},);
 					}
 				}
-			navigator.clipboard.writeText(JSON.stringify(exportData));
+			KDExportWardrobeDataToClipboardOrModal(JSON.stringify(exportData), "KDCreateOutfit");
 			return true;
 		}, true, 945, 950, 100, 60,
 		TextGet("KDCreateOutfit"), "#99ff99", "");
@@ -1851,7 +1958,7 @@ function KDDrawWardrobe(_screen: string, Character: Character) {
 						},);
 					}
 				}
-			navigator.clipboard.writeText(JSON.stringify(exportData));
+			KDExportWardrobeDataToClipboardOrModal(JSON.stringify(exportData), "KDCreateAlwaysDress");
 			return true;
 		}, true, 945, 890, 100, 60,
 		TextGet("KDCreateAlwaysDress"), "#99ff99", "");
@@ -1872,7 +1979,7 @@ function KDDrawWardrobe(_screen: string, Character: Character) {
 						},);
 					}
 				}
-			navigator.clipboard.writeText(JSON.stringify(exportData));
+			KDExportWardrobeDataToClipboardOrModal(JSON.stringify(exportData), "KDCreateFace");
 			return true;
 		}, true, 945, 710, 100, 60,
 		TextGet("KDCreateFace"), "#99ff99", "");
@@ -1891,7 +1998,7 @@ function KDDrawWardrobe(_screen: string, Character: Character) {
 						},);
 					}
 				}
-			navigator.clipboard.writeText(JSON.stringify(exportData));
+			KDExportWardrobeDataToClipboardOrModal(JSON.stringify(exportData), "KDCreateHair");
 			return true;
 		}, true, 945, 830, 100, 60,
 		TextGet("KDCreateHair"), "#99ff99", "");
@@ -1910,7 +2017,7 @@ function KDDrawWardrobe(_screen: string, Character: Character) {
 						},);
 					}
 				}
-			navigator.clipboard.writeText(JSON.stringify(exportData));
+			KDExportWardrobeDataToClipboardOrModal(JSON.stringify(exportData), "KDCreateCosplay");
 			return true;
 		}, true, 945, 770, 100, 60,
 		TextGet("KDCreateCosplay"), "#99ff99", "");

--- a/Game/src/player/KDWardrobe.ts
+++ b/Game/src/player/KDWardrobe.ts
@@ -347,17 +347,6 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 
 		if (!KDClipboardDisabled) {
 			if (TestMode)
-				DrawButtonKDEx("ExportAllProps", (_bdata) => {
-					if (Model.Properties) {
-						navigator.clipboard.writeText(JSON.stringify(Model.Properties));
-					}
-					return true;
-				}, true, X + width/2 + 10, YY - 40, width/2 - 10, 30, TextGet("KDExportAllProps"), KDBaseMint);
-
-			DrawButtonKDEx("KDCopyProps", (_bdata) => {
-				navigator.clipboard.writeText(JSON.stringify(Properties));
-				return true;
-			}, true, X, YY, width/2 - 10, 30, TextGet("KDCopyLayer"), KDBaseWhite);
 			DrawButtonKDEx("KDPasteProps", (_bdata) => {
 				navigator.clipboard.readText()
 					.then(text => {
@@ -376,6 +365,19 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 				return true;
 			}, true, X, YY - 40, width/2 - 10, 30, TextGet("KDPasteLayer"), KDBaseWhite);
 		} else {
+			if (TestMode) {
+				DrawButtonKDEx("ExportAllProps", (_bdata) => {
+					if (Model.Properties) {
+						KDExportWardrobeDataToClipboardOrModal(JSON.stringify(Model.Properties), "All Layers Props");
+					}
+					return true;
+				}, true, X + width/2 + 10, YY - 40, width/2 - 10, 30, TextGet("KDExportAllProps"), KDBaseMint);
+
+				DrawButtonKDEx("KDCopyProps", (_bdata) => {
+					KDExportWardrobeDataToClipboardOrModal(JSON.stringify(Properties), "Layer Props");
+					return true;
+				}, true, X, YY, width/2 - 10, 30, TextGet("KDCopyLayer"), KDBaseWhite);
+			}
 			let CF = KDTextField("KDCopyProperties", X, YY - 70,
 				width, 30, undefined, undefined, "300", 12);
 			if (CF.Created) {

--- a/Game/src/player/KDWardrobe.ts
+++ b/Game/src/player/KDWardrobe.ts
@@ -376,7 +376,7 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 				return true;
 			}, true, X, YY - 40, width/2 - 10, 30, TextGet("KDPasteLayer"), KDBaseWhite);
 		} else {
-			let CF = KDTextField("KDCopyProperties", X, YY - 50,
+			let CF = KDTextField("KDCopyProperties", X, YY - 70,
 				width, 30, undefined, undefined, "300", 12);
 			if (CF.Created) {
 				CF.Element.oninput = (_event: any) => {
@@ -541,7 +541,7 @@ function KDDrawColorSliders(X: number, Y: number, C: Character, Model: Model): v
 				return true;
 			}, true, X, YY - 40, width/2 - 10, 30, TextGet("KDPasteLayer"), KDBaseWhite);
 		} else {
-			let CF = KDTextField("KDCopyFilter", X, YY - 50, width, 30, undefined, undefined, "300");
+			let CF = KDTextField("KDCopyFilter", X, YY - 70, width, 30, undefined, undefined, "300");
 			if (CF.Created) {
 				CF.Element.oninput = (_event: any) => {
 					let value = ElementValue("KDCopyFilter");


### PR DESCRIPTION
These commits add a new popup for the wardrobe to be used when the system clipboard is unavailable in order to show the data that would have been copied to the clipboard, a helper function to simplify deciding between copy-to-clipboard or popup, and modify various buttons in order to use the popup.

This was made with the focus of Firefox, since that engine doesn't expose the clipboard, but was also tested to not cause problems under Chromium. I have also done limited testing in a native version via copying my build into the resources folder, but I'm unsure if that was a good enough way to do so, or just not enough testing.

Explanation of commits:
- 9cdc931
  + Implements the new popup in `KDWardrobeExportPopup` and the export helper function in `KDExportWardrobeDataToClipboardOrModal`
  + Removes the clipboard disabled check surrounding the "Export Face/Cosplay/Hair/AlwaysDress/Outfit" buttons and modifies them to use `KDExportWardrobeDataToClipboardOrModal`
- feefa80
  + Adjusts the height of the "KDCopyProperties" and "KDCopyFilters" text boxes shown when the clipboard is disabled, in order to avoid overlapping buttons which are re-added in 7bf578b and d5e939a
- 7bf578b
  + Moves the draw call for layer properties "Export All Props" and "Copy" buttons so they're still shown when the clipboard is disabled, and modifies them to use `KDExportWardrobeDataToClipboardOrModal`
- d5e939a
  + Moves the draw call for layer colors "Export All Layers" and "Copy" buttons so they're still shown when the clipboard is disabled, and modifies them to use `KDExportWardrobeDataToClipboardOrModal`
- 9c51188
  + Fixes a mistake I failed to catch in 7bf578b and d5e939a, which caused the modified buttons to not be shown when clipboard is enabled

I haven't commented my new functions in the code, so if that is desired, I will do so. But for reference here, here's some notes about them:
- `KDWardrobeExportPopup(data: string, title: string)`
  + `data` is the string to be shown in the code section of the popup (the same section as where the crash report goes in the crash popup). All current calls use `JSON.stringify` on the outfit data for this parameter
  + `title` is the title of the popup. Can either be a text key or a plain string. If the string provided in `title` is a valid text key, the corresponding value will be used for that key. Otherwise, the popup title will just be set to `title`
- `KDExportWardrobeDataToClipboardOrModal(data: string, title: string)`
  + `data` is passed unmodified to either `KDWardrobeExportPopup` or `navigator.clipboard.writeText`, depending on `KDClipboardDisabled`
  + `title`, if it is set, is passed directly to `KDWardrobeExportPopup` if that gets called. If `title` is not set or is empty, it will be set to a default value of "Wardrobe Data"