### PR TITLE
Variable Gold Lock Timer

### DIFF
--- a/Game/src/restraint/KDLocks.ts
+++ b/Game/src/restraint/KDLocks.ts
@@ -1062,8 +1062,8 @@ let KDLocks: Record<string, KDLockType> = {
 		doLock: (data) => {
 			if (data.item && !data.link) {
 				if (!data.item.data) data.item.data = {};
-				const r = KDRestraint(data.item);
-				data.item.data.lockTimer = MiniGameKinkyDungeonLevel + (r.lockDuration || 2);
+				const r = KDRestraint(data.item); //added line
+				data.item.data.lockTimer = MiniGameKinkyDungeonLevel + (r.lockDuration || 2); //Modified line. Makes duration variable.
 			}
 		},
 		// Start of level -- for gold locks and others

--- a/Game/src/restraint/KDLocks.ts
+++ b/Game/src/restraint/KDLocks.ts
@@ -1062,7 +1062,8 @@ let KDLocks: Record<string, KDLockType> = {
 		doLock: (data) => {
 			if (data.item && !data.link) {
 				if (!data.item.data) data.item.data = {};
-				data.item.data.lockTimer = MiniGameKinkyDungeonLevel + 2;
+				const r = KDRestraint(data.item);
+				data.item.data.lockTimer = MiniGameKinkyDungeonLevel + (r.lockDuration || 2);
 			}
 		},
 		// Start of level -- for gold locks and others


### PR DESCRIPTION
This change softcodes the gold lock duration. Now, it can be adjusted within the restraint data by using 'lockDuration: x' where x is the duration of the lock. The game will still default to 2 if no lockDuration entry is present.