### PR TITLE
Fix random ranges.

### DIFF
--- a/Game/src/fight/KinkyDungeonFight.ts
+++ b/Game/src/fight/KinkyDungeonFight.ts
@@ -854,7 +854,7 @@ function KDDamageEnemy(Enemy: entity, Damage: damageInfo, Ranged: boolean, NoMsg
 		else if (Spell.enemySpell) predata.faction = "Enemy";
 		else predata.faction = "Player";
 	}
-	
+
 	if (ret) {
 		return predata;
 	}
@@ -1068,8 +1068,8 @@ function KDDamageEnemy(Enemy: entity, Damage: damageInfo, Ranged: boolean, NoMsg
 						Type: TextGet("KinkyDungeonDamageType" + predata.type)
 					}), KDBaseLightGrey, 1, false, false, Enemy, "Combat");
 				}
-				
-				
+
+
 
 				while (predata.dmgDealt > 0 && Enemy.blocks >= 1 && (predata.dmgDealt > Enemy.hp * 0.1 || predata.dmgDealt > Enemy.Enemy.maxhp*0.5)) {
 					blockCount += 1;
@@ -1925,7 +1925,7 @@ function KinkyDungeonUpdateBullets(delta: number, Allied?: boolean): void {
 				end = false;
 				let checkCollision = (b.bullet.faction == "Player" && (b.x != KinkyDungeonPlayerEntity.x || b.y != KinkyDungeonPlayerEntity.y))
 					|| justBorn || (b.x != startx || b.y != starty) || (!b.vx && !b.vy) || (KDistEuclidean(b.vx, b.vy) < 0.9); // Check collision for bullets only once they leave their square or if they are slower than one
-				
+
 				if ((checkCollision && !KinkyDungeonBulletsCheckCollision(b, undefined, undefined, delta - d, false)) || outOfTime || outOfRange) {
 					if (!(b.bullet.spell
 						&& (
@@ -2137,7 +2137,7 @@ function KinkyDungeonCreateWarningTile(x: number, y: number, color: string = KDB
 
 function KinkyDungeonParseExtraWarningTiles(delta: number) {
 	for (let i = 0; i < KinkyDungeonExtraWarningTiles.length; i++) {
-		
+
 		KDAddWarning({
 			source: 0,
 			type: 2,
@@ -2268,7 +2268,7 @@ function KinkyDungeonBulletHit(b: KDBullet, born: number, outOfTime?: boolean, o
 		if (!xx) xx = b.x;
 		if (!yy) yy = b.y;
 		let res = KinkyDungeonCastSpell(xx, yy, KinkyDungeonFindSpell(b.bullet.cast.spell, true), undefined, undefined, b);
-	
+
 		if (res.data?.bulletfired) res.data.bulletfired.collisionUpdate = true;
 	}
 
@@ -2472,7 +2472,7 @@ function KinkyDungeonBulletHit(b: KDBullet, born: number, outOfTime?: boolean, o
 			for (let Y = -Math.ceil(rad); Y <= Math.ceil(rad); Y++) {
 				if (AOECondition(b.x, b.y, b.x + X, b.y + Y, rad, KDBulletAoEMod(b), b.ox, b.oy)) {
 					let dd = KDistEuclidean(X, Y) / rad;
-					let LifetimeBonus = (b.bullet.spell?.lifetimeHitBonus) ? Math.floor(KDRandom() * b.bullet.spell?.lifetimeHitBonus) : 0;
+					let LifetimeBonus = (b.bullet.spell?.lifetimeHitBonus) ? Math.floor(KDRandom() * (b.bullet.spell?.lifetimeHitBonus + 1)) : 0;
 					let newB: KDBullet = {
 						delay: dd,
 						born: born,
@@ -2932,7 +2932,7 @@ function KinkyDungeonBulletTrail(b: KDBullet): boolean {
 						trail = true;
 						let newB: KDBullet = {
 							born: 0,
-							time: b.bullet.spell?.trailLifetime + (b.bullet.spell?.trailLifetimeBonus ? Math.floor(KDRandom() * b.bullet.spell.trailLifetimeBonus) : 0),
+							time: b.bullet.spell?.trailLifetime + (b.bullet.spell?.trailLifetimeBonus ? Math.floor(KDRandom() * (b.bullet.spell.trailLifetimeBonus + 1)) : 0),
 							x: b.x + X, y: b.y + Y,
 							vx: 0, vy: 0,
 							xx: b.x + X, yy: b.y + Y,
@@ -2952,7 +2952,7 @@ function KinkyDungeonBulletTrail(b: KDBullet): boolean {
 									evadeable: b.bullet.spell?.trailEvadeable,
 									noblock: b.bullet.spell?.trailNoBlock,
 									damage: !(b.bullet.spell?.trailPower) ? undefined
-										: ((b.bullet.spell?.trailPower) + (((b.bullet.spell?.trailPower && b.bullet.spell?.power > 0) ? 
+										: ((b.bullet.spell?.trailPower) + (((b.bullet.spell?.trailPower && b.bullet.spell?.power > 0) ?
 											(b.bullet.spell?.trailPower / b.bullet.spell.power) * b.bullet.dmgBoost || 0 : 0))) * (b.bullet.dmgMult != undefined ? b.bullet.dmgMult : 1),
 									type: b.bullet.spell?.trailDamage,
 									boundBonus: b.bullet.spell?.boundBonus,
@@ -3172,7 +3172,7 @@ function KDHealNPC(enemy: entity, amount: number, source: number, bullet?: KDBul
 	let data: HealData = {
 		enemy: enemy,
 		amount: amount,
-		source: source, 
+		source: source,
 		bullet: bullet,
 	}
 	KinkyDungeonSendEvent("heal", data);
@@ -3181,7 +3181,7 @@ function KDHealNPC(enemy: entity, amount: number, source: number, bullet?: KDBul
 	enemy = data.enemy;
 	bullet = data.bullet;
 	if (amount == 0) return;
-	
+
 	let origHP = enemy.hp;
 	enemy.hp = Math.min(enemy.hp + amount, enemy.Enemy.maxhp);
 
@@ -3433,10 +3433,10 @@ function KinkyDungeonSendWeaponEvent(Event: string, data: any, forceWeapon?: ite
 	if (KDGameData.Offhand
 		&& KinkyDungeonInventoryGetWeapon(KDGameData.Offhand)) {
 		let weapon = KDWeapon(KinkyDungeonInventoryGetWeapon(KDGameData.Offhand));
-			
+
 		let events = (KinkyDungeonInventoryGetWeapon(KDGameData.Offhand))?.events
 			|| KDWeapon(KinkyDungeonInventoryGetWeapon(KDGameData.Offhand))?.events;
-			
+
 		let Vevents = events ? null : (KinkyDungeonWeaponVariants[ KinkyDungeonInventoryGetWeapon(KDGameData.Offhand)?.inventoryVariant
 			|| KinkyDungeonInventoryGetWeapon(KDGameData.Offhand)?.name]?.events);
 		if (Vevents)

--- a/Game/src/item/KinkyDungeonLoot.ts
+++ b/Game/src/item/KinkyDungeonLoot.ts
@@ -1174,12 +1174,12 @@ function KDGenerateMinorLoot(lootType: string, coord: WorldCoord, tile: any, x: 
 		for (let l of loots) {
 			let itemType = KDGetItemType(l);
 			if (itemType == Consumable) {
-				KDAddConsumable(l.name, (l.quantity || 1) + Math.floor(KDRandom() * l.extraQuantity || 0), container);
+				KDAddConsumable(l.name, (l.quantity || 1) + Math.floor(KDRandom() * (l.extraQuantity + 1 || 0)), container);
 			} else if (itemType == Weapon && !container.items[l.name]) {
 				KDInvAddWeapon(container, l.name);
 			} else if (itemType == LooseRestraint) {
 				KDInvAddLoose(container, l.name, undefined, tile.Faction,
-					(l.quantity || 1) + Math.floor(KDRandom() * l.extraQuantity || 0));
+					(l.quantity || 1) + Math.floor(KDRandom() * (l.extraQuantity + 1 || 0)));
 			}
 		}
 	}

--- a/Game/src/item/KinkyDungeonLoot.ts
+++ b/Game/src/item/KinkyDungeonLoot.ts
@@ -287,7 +287,7 @@ function KinkyDungeonLootEvent(Loot: any, Floor: number, Replacemsg: string, Loc
 
 		let enchantVariant = "";
 		let enchant_extra = [];
-		let enchants = (Loot.minEnchants || 1) + Math.floor(KDRandom() * ((Loot.maxEnchants || 1) - (Loot.minEnchants || 1)));
+		let enchants = (Loot.minEnchants || 1) + Math.floor (KDRandom() * ((Loot.maxEnchants || 1) + 1 - (Loot.minEnchants || 1)));
 
 		if (Loot.enchantlist && (Loot.enchantchance == undefined || KDRandom() < Loot.enchantchance + (Loot.enchantscale|| 0) * levelPercent)) {
 			while (enchants > 0) {
@@ -370,8 +370,8 @@ function KinkyDungeonLootEvent(Loot: any, Floor: number, Replacemsg: string, Loc
 		let enchantVariant = "";
 		let enchant_extra = [];
 		let hex_extra = [];
-		let enchants = (Loot.minEnchants || 1) + Math.floor(KDRandom() * ((Loot.maxEnchants || 1) - (Loot.minEnchants || 1)));
-		let curses = (Loot.minHex || 1) + Math.floor(KDRandom() * ((Loot.maxHex || 1) - (Loot.minHex || 1)));
+		let enchants = (Loot.minEnchants || 1) + Math.floor (KDRandom() * ((Loot.maxEnchants || 1) + 1 - (Loot.minEnchants || 1)));
+		let curses = (Loot.minHex || 1) + Math.floor (KDRandom() * ((Loot.maxHex || 1) + 1 - (Loot.minHex || 1)));
 		if (hexed) {
 			while (curses > 0) {
 				let curs = KDGetByWeight(KinkyDungeonGetHexByListWeighted(Loot.hexlist, armor, false, Loot.hexlevelmin, Loot.hexlevelmax, [hexVariant, ...hex_extra]));

--- a/Game/src/magic/KinkyDungeonMagic.ts
+++ b/Game/src/magic/KinkyDungeonMagic.ts
@@ -1170,7 +1170,7 @@ function KinkyDungeonCastSpell(targetX: number, targetY: number, spell: spell, e
 					aoe: spell.type == "dot" ? spell.bulletAoE : undefined,
 					source: spell.noSource ? undefined : ((entity?.player ? -1 : entity?.id) || bullet?.bullet?.source),
 					lifetime:spell.delay +
-						(spell.delayRandom ? Math.floor(KDRandom() * spell.delayRandom) : 0),
+						(spell.delayRandom ? Math.floor(KDRandom() * (spell.delayRandom + 1)) : 0),
 					cast: cast, dot: spell.dot, events: spell.events, alwaysCollideTags: spell.alwaysCollideTags,
 					bulletColor: spell.bulletColor, bulletLight: spell.bulletLight,
 					bulletSpin: spell.bulletSpin,
@@ -1402,7 +1402,7 @@ function KinkyDungeonCastSpell(targetX: number, targetY: number, spell: spell, e
 				KinkyDungeonAggroAction('magic', {});
 			if (spell.school) KinkyDungeonTickBuffTag(KinkyDungeonPlayerEntity, "cast_" + spell.school.toLowerCase(), 1);
 		}
-		
+
 		KinkyDungeonSendEvent("playerCast", data);
 		if (KDGameData.HeelPowerEffective > 0) {
 			if (spell.components?.includes("Arms"))
@@ -1449,7 +1449,7 @@ function KinkyDungeonClickSpellChoice(I: number, CurrentSpell: number) {
 	if (KinkyDungeonSpellChoicesToggle[I] && KinkyDungeonSpells[KinkyDungeonSpellChoices[I]].cancelAutoMove) {
 		//KinkyDungeonFastMove = false;
 		//KinkyDungeonFastMoveSuppress = false;
-		
+
 		KinkyDungeonFastMovePath = [];
 	}
 }

--- a/Game/src/prison/KinkyDungeonJail.ts
+++ b/Game/src/prison/KinkyDungeonJail.ts
@@ -771,7 +771,7 @@ function KinkyDungeonHandleJailSpawns(delta: number, useExistingGuard: boolean =
 	}
 	if (!KDMapData.Entities.includes(KinkyDungeonJailGuard())) {
 		if (KDGameData.GuardSpawnTimer == 0 || KinkyDungeonJailGuard())
-			KDGameData.GuardSpawnTimer = 14 + Math.floor(KDRandom() * (KDGameData.GuardSpawnTimerMax - KDGameData.GuardSpawnTimerMin));
+			KDGameData.GuardSpawnTimer = 14 + Math.floor(KDRandom() * (KDGameData.GuardSpawnTimerMax + 1 - KDGameData.GuardSpawnTimerMin));
 		KDGameData.JailGuard = 0;
 	}
 	if (KDGameData.GuardSpawnTimerMax == undefined) {
@@ -926,7 +926,7 @@ function KinkyDungeonHandleLeashTour(xx: number, yy: number, type: string): void
 			let enemy = KinkyDungeonEnemyAt(KinkyDungeonPlayerEntity.x, KinkyDungeonPlayerEntity.y);
 			if (enemy) enemy.x += 1;
 			KinkyDungeonJailGuard().CurrentAction = "jailWander";
-			KDGameData.KinkyDungeonJailTourTimer = KDGameData.KinkyDungeonJailTourTimerMin + Math.floor((KDGameData.KinkyDungeonJailTourTimerMax - KDGameData.KinkyDungeonJailTourTimerMin) * KDRandom());
+			KDGameData.KinkyDungeonJailTourTimer = KDGameData.KinkyDungeonJailTourTimerMin + Math.floor((KDGameData.KinkyDungeonJailTourTimerMax + 1 - KDGameData.KinkyDungeonJailTourTimerMin) * KDRandom());
 			KinkyDungeonJailGuard().gx = KinkyDungeonJailGuard().x;
 			KinkyDungeonJailGuard().gy = KinkyDungeonJailGuard().y;
 		} else {
@@ -1379,7 +1379,7 @@ function KDEnterDragonLair(dragon: entity, lairType: string = "DragonLair") {
 
 	let slot = KDGetWorldMapLocation(KDCoordToPoint(dragon.homeCoord || KDGetCurrentLocation()));
 	let setFutureHomeCoord = false; // for dragons without a home
-	
+
 	if(slot == undefined) {
 		// thanks Gen for fix
 		if (!dragon.homeCoord) setFutureHomeCoord = true;
@@ -2256,7 +2256,7 @@ let KDCustomDefeatUniforms = {
 		for (let i = 0; i < 30; i++) {
 			let r = KinkyDungeonGetRestraint({tags: (i < (KinkyDungeonStatsChoice.has("NoWayOut") ? 3 : 1) ? ["wolfCuffs"] : ["wolfGear", "wolfRestraints"])},
 			Math.max(KDGetEffLevel(), 8), "grv", true, "Red",
-			
+
 			undefined, undefined, undefined, undefined, undefined, undefined,
 			undefined, undefined, undefined ,undefined, {
 				suppressTightPerk: MiniGameKinkyDungeonLevel == 0
@@ -2272,7 +2272,7 @@ let KDCustomDefeatUniforms = {
 		for (let i = 0; i < 10; i++) {
 			let r = KinkyDungeonGetRestraint({tags: (["linkRegular"])},
 			Math.max(KDGetEffLevel(), 6), "grv", true, "Red",
-			
+
 			undefined, undefined, undefined, undefined, undefined, undefined,
 			undefined, undefined, undefined ,undefined, {
 				suppressTightPerk: MiniGameKinkyDungeonLevel == 0
@@ -2294,7 +2294,7 @@ let KDCustomDefeatUniforms = {
 		for (let i = 0; i < 20; i++) {
 			let r = KinkyDungeonGetRestraint({tags: ["maidRestraints", "maidVibeRestraints", "noMaidJacket"]},
 				Math.max(KDGetEffLevel(), 9), "grv", true, "Purple",
-			
+
 				undefined, undefined, undefined, undefined, undefined, undefined,
 				undefined, undefined, undefined ,undefined, {
 					suppressTightPerk: MiniGameKinkyDungeonLevel == 0
@@ -2305,7 +2305,7 @@ let KDCustomDefeatUniforms = {
 		for (let i = 0; i < 10; i++) {
 			let r = KinkyDungeonGetRestraint({tags: ["handcuffer", "linkRegular"]},
 				Math.max(KDGetEffLevel(), 6), "grv", true, "Purple",
-			
+
 				undefined, undefined, undefined, undefined, undefined, undefined,
 				undefined, undefined, undefined ,undefined, {
 					suppressTightPerk: MiniGameKinkyDungeonLevel == 0
@@ -2319,12 +2319,12 @@ let KDCustomDefeatUniforms = {
 		KinkyDungeonSetDress("Maid", "Maid");
 	},
 	DollShoppe: () => {
-		KinkyDungeonAddRestraintIfWeaker("HeavyLatexCatsuit", 5, true, "Red", 
+		KinkyDungeonAddRestraintIfWeaker("HeavyLatexCatsuit", 5, true, "Red",
 			false, undefined, undefined, "Jail", true);
 		for (let i = 0; i < 30; i++) {
 			let r = KinkyDungeonGetRestraint({tags: ["latexRestraints", "latexStart", "latexCollar", "latexRestraintsForced"]},
 				Math.max(KDGetEffLevel(), 6), "grv", true, "Purple",
-			
+
 				undefined, undefined, undefined, undefined, undefined, undefined,
 				undefined, undefined, undefined ,undefined, {
 					suppressTightPerk: MiniGameKinkyDungeonLevel == 0
@@ -2375,7 +2375,7 @@ let KDCustomDefeatUniforms = {
 			let r = KinkyDungeonGetRestraint({tags: ["ropeRestraints", "ropeRestraints2", "ropeRestraintsHogtie", "ropeRestraintsWrist",
 				"tapeRestraints", "genericToys"]},
 				Math.max(KDGetEffLevel(), 24), "grv", true, undefined,
-			
+
 				undefined, undefined, undefined, undefined, undefined, undefined,
 				undefined, undefined, undefined ,undefined, {
 					suppressTightPerk: MiniGameKinkyDungeonLevel == 0
@@ -2410,7 +2410,7 @@ let KDCustomDefeatUniforms = {
 		for (let i = 0; i < 30; i++) {
 			let r = KinkyDungeonGetRestraint({tags: ["obsidianRestraints", "ornateChastity", "genericToys", "linkRegular"]},
 				Math.max(KDGetEffLevel(), 7), "grv", true, "Red",
-			
+
 				undefined, undefined, undefined, undefined, undefined, undefined,
 				undefined, undefined, undefined ,undefined, {
 					suppressTightPerk: MiniGameKinkyDungeonLevel == 0
@@ -2441,7 +2441,7 @@ function KDFixPlayerClothes(faction: string) {
 }
 
 function KDResetGuardSpawnTimer() {
-	KDGameData.GuardSpawnTimer = 4 + Math.floor(KDRandom() * (KDGameData.GuardSpawnTimerMax - KDGameData.GuardSpawnTimerMin));
+	KDGameData.GuardSpawnTimer = 4 + Math.floor(KDRandom() * (KDGameData.GuardSpawnTimerMax + 1 - KDGameData.GuardSpawnTimerMin));
 }
 
 let KDChestRank = {
@@ -2607,7 +2607,7 @@ function KDGetFurnitureCriteria(entity: entity): (x: number, y: number, point: K
 
 			return !entity || !furniture || (restrainttags && (
 				!KDCanEquipItemOnNPC(
-					KinkyDungeonGetRestraint({tags: restrainttags}, KDGetEffLevel(),KDCurrIndex(), false, 
+					KinkyDungeonGetRestraint({tags: restrainttags}, KDGetEffLevel(),KDCurrIndex(), false,
 					undefined, undefined, undefined, undefined, undefined, true),
 					id, false, undefined, undefined
 				)
@@ -2615,5 +2615,5 @@ function KDGetFurnitureCriteria(entity: entity): (x: number, y: number, point: K
 		}
 	}
 
-	
+
 }

--- a/Game/src/prison/KinkyDungeonJailList.ts
+++ b/Game/src/prison/KinkyDungeonJailList.ts
@@ -75,7 +75,7 @@ let KDJailEvents: Record<string, {weight: (guard: any, xx: any, yy: any) => numb
 			if (KinkyDungeonVisionGet(guard.x, guard.y))
 				KinkyDungeonSendTextMessage(10, TextGet("KinkyDungeonGuardAppear").replace("EnemyName", TextGet("Name" + guard.Enemy.name)), KDBaseWhite, 6);
 			KDGameData.GuardTimer = KDGameData.GuardTimerMax;
-			KDGameData.GuardSpawnTimer = KDGameData.GuardSpawnTimerMin + Math.floor(KDRandom() * (KDGameData.GuardSpawnTimerMax - KDGameData.GuardSpawnTimerMin));
+			KDGameData.GuardSpawnTimer = KDGameData.GuardSpawnTimerMin + Math.floor(KDRandom() * (KDGameData.GuardSpawnTimerMax + 1 - KDGameData.GuardSpawnTimerMin));
 		},
 	},
 	"useCurrentGuard": {
@@ -121,7 +121,7 @@ let KDJailEvents: Record<string, {weight: (guard: any, xx: any, yy: any) => numb
 
 			//if (KinkyDungeonVisionGet(guard.x, guard.y))
 			KDGameData.GuardTimer = KDGameData.GuardTimerMax;
-			KDGameData.GuardSpawnTimer = KDGameData.GuardSpawnTimerMin + Math.floor(KDRandom() * (KDGameData.GuardSpawnTimerMax - KDGameData.GuardSpawnTimerMin));
+			KDGameData.GuardSpawnTimer = KDGameData.GuardSpawnTimerMin + Math.floor(KDRandom() * (KDGameData.GuardSpawnTimerMax + 1 - KDGameData.GuardSpawnTimerMin));
 		},
 	},
 	"spawnRescue": {


### PR DESCRIPTION
Entries in `KinkyDungeonLootTable[]` contain the fields:

	minEnchants
	maxEnchants
	minHex
	maxHex

At a glance, the ranges appear inclusive.  However, the calculation in `KinkyDungeonLootEvent()` fails to take into account that `KDRandom()` returns a value in the range [ 0.0, 1.0 ), which means that, after `Math.floor()`, the upper value of the range would never be selected.

Add a fencepost to the calculation of quantities to ensure the full intended range can be selected.

(Note: `minHex` and `maxHex` appear in this change, but I can find no items that use those fields.)