### PR TITLE
Fix removing dynamically linked item when morphing top restraint

### DIFF
--- a/Game/src/item/KinkyDungeonInventory.ts
+++ b/Game/src/item/KinkyDungeonInventory.ts
@@ -3167,7 +3167,7 @@ function KDMorphToInventoryVariant(item: item, variant: KDRestraintVariant, pref
 
 		let lock = item.lock;
 
-		KinkyDungeonRemoveRestraintSpecific(item, false, true, true, false, false, undefined, true);
+		KinkyDungeonRemoveRestraintSpecific(item, false, false, true, false, false, undefined, true);
 
 		KDEquipInventoryVariant(
 			variant,


### PR DESCRIPTION
When `KDMorphToInventoryVariant` is applied on the top item of an item group, all dynamically linked item gets removed.
`KinkyDungeonRemoveRestraintSpecific` should have `Add` set to `false` to only remove single item.