### PR TITLE
Native browser CompressionStream (gzip) for saves

### DIFF
--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -7421,8 +7421,18 @@ async function KDCompressGzip(input: string): Promise<string> {
 		offset += chunk.length;
 	}
 
-	// Uint8Array.toBase64() needs ES2026+ lib; cast to any until tsconfig catches up
-	return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + (compressed as any).toBase64();
+	// Use toBase64() where available (Chrome 137+), fall back to btoa for older engines
+	let b64: string;
+	if (typeof (compressed as any).toBase64 === 'function') {
+		b64 = (compressed as any).toBase64();
+	} else {
+		let binary = '';
+		for (let i = 0; i < compressed.length; i++) {
+			binary += String.fromCharCode(compressed[i]);
+		}
+		b64 = btoa(binary);
+	}
+	return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + b64;
 }
 
 /**

--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -7393,7 +7393,7 @@ function KDDrawGameSetupTabs(_xOffset: number = 500, xpad: number = 10, num: num
 
 
 /**
- * Compress a string using native browser gzip, returns 'gzip:' + base64
+ * Compress a string using native browser gzip, returns a data: URI with MIME type
  */
 async function KDCompressGzip(input: string): Promise<string> {
 	const encoder = new TextEncoder();
@@ -7421,13 +7421,8 @@ async function KDCompressGzip(input: string): Promise<string> {
 		offset += chunk.length;
 	}
 
-	// Convert to base64
-	let binary = '';
-	for (let i = 0; i < compressed.length; i++) {
-		binary += String.fromCharCode(compressed[i]);
-	}
-	// return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + btoa(binary);
-	return 'gzip:' + btoa(binary);
+	// Uint8Array.toBase64() needs ES2026+ lib; cast to any until tsconfig catches up
+	return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + (compressed as any).toBase64();
 }
 
 /**
@@ -7453,18 +7448,18 @@ async function KDCompressForSave(json: string): Promise<string> {
 
 /**
  * Decompress save data - auto-detects format:
- * - 'gzip:' prefix (our format) - translates to data URI
- * - 'data:' prefix (PR #223 format) - passes directly to fetch
+ * - 'data:' prefix with MIME type - validates type if present, decompresses gzip
  * - anything else - legacy LZString
  */
 async function KDDecompressForLoad(data: string): Promise<string> {
 	const trimmed = "".concat(...data.trim().split('\n'));
-	if (trimmed.startsWith('gzip:')) {
-		// Translate our simple format to a data URI
-		return KDDecompressDataUri('data:application/gzip;base64,' + trimmed.slice(5));
-	}
 	if (trimmed.startsWith('data:')) {
-		// Support PR #223 format directly
+		// Validate save type from MIME if present (reject non-game saves)
+		const typeMatch = trimmed.match(/vnd\.straightlaced\.kinkydungeon\.save\.(\w+)/);
+		if (typeMatch && typeMatch[1] !== 'game') {
+			console.log(`Expected game save, got ${typeMatch[1]}`);
+			return null;
+		}
 		return KDDecompressDataUri(trimmed);
 	}
 	return LZString.decompressFromBase64(trimmed);

--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -4694,12 +4694,12 @@ function KDDrawLoadMenu() {
 		for (let i = startSaveSlot; i < endSaveSlot; i++) {
 			let num = (i);
 			// Slot button
-			DrawButtonKDEx(TextGet("KDSaveSlotButton") + num, () => {
+			DrawButtonKDEx(TextGet("KDSaveSlotButton") + num, async () => {
 				console.log("Pressed button for save slot " + num);
 				loadedSaveforPreview = null;
 				LoadMenuCurrentSlot = num;
 				LoadMenuCurrentSave = loadedsaveslots[num - 1];
-				loadedSaveforPreview = KinkyDungeonLoadPreview(LoadMenuCurrentSave);
+				loadedSaveforPreview = await KinkyDungeonLoadPreview(LoadMenuCurrentSave);
 
 				let origSaveSlot = KDSaveSlot;
 				KDSaveSlot = num;
@@ -4783,13 +4783,13 @@ function KDDrawLoadMenu() {
 	else {
         for (let i = 1; i < 3; i++) {
             let num = (i);
-            DrawButtonKDEx(TextGet("KDSaveSlotButton") + num, () => {
+            DrawButtonKDEx(TextGet("KDSaveSlotButton") + num, async () => {
 				// Slot button
                 console.log("Pressed button for save slot " + num);
                 loadedSaveforPreview = null;
                 LoadMenuCurrentSlot = num;
                 LoadMenuCurrentSave = loadedcloudsaveslots[num - 1];
-                loadedSaveforPreview = KinkyDungeonLoadPreview(LoadMenuCurrentSave);
+                loadedSaveforPreview = await KinkyDungeonLoadPreview(LoadMenuCurrentSave);
 				let origSaveSlot = KDSaveSlot;
 				KDSaveSlot = num;
 				// @ts-ignore
@@ -4880,14 +4880,14 @@ function KDDrawLoadMenu() {
 	ElementPosition("saveInputField", CombarXX + 215, YY + 145 - 33, 400, 300 - 85);
 	let newValue = ElementValue("saveInputField");
 	// Load from Code button
-	DrawButtonKDEx("LoadFromCodeButton", () => {
+	DrawButtonKDEx("LoadFromCodeButton", async () => {
 		KinkyDungeonKeybindingsTemp = Object.assign({}, KinkyDungeonKeybindingsTemp);
 		LoadMenuCurrentSlot = undefined;
 		if (newValue) {
-			loadedSaveforPreview = KinkyDungeonLoadPreview(newValue);
+			loadedSaveforPreview = await KinkyDungeonLoadPreview(newValue);
 			if (loadedSaveforPreview) LoadMenuCurrentSlot = -1;
 		} else if (KDSlot0) {
-			loadedSaveforPreview = KinkyDungeonLoadPreview(KDSlot0);
+			loadedSaveforPreview = await KinkyDungeonLoadPreview(KDSlot0);
 			if (loadedSaveforPreview) LoadMenuCurrentSlot = 0;
 			LoadMenuCurrentSave = KDSlot0;
 		}
@@ -5539,7 +5539,7 @@ function KinkyDungeonDressModelPreview() {
 /**
  * Generate Preview data function
  */
-function KinkyDungeonLoadPreview(String: string): KinkyDungeonSave {
+async function KinkyDungeonLoadPreview(String: string): Promise<KinkyDungeonSave> {
 	if (!String) {
 		return {
 			// @ts-ignore
@@ -5548,7 +5548,7 @@ function KinkyDungeonLoadPreview(String: string): KinkyDungeonSave {
 		};
 	}
 	try {
-		let str: string = DecompressB64(String.trim());
+		let str: string = await KDDecompressForLoad(String.trim());
 		let returndata: KinkyDungeonSave = null;
 
 		// We do a little JS witchery here
@@ -5767,11 +5767,9 @@ function KinkyDungeonLoadPreview(String: string): KinkyDungeonSave {
 }
 
 /**
- * KinkyDungeonStartNewGame was split into 4 functions to isolate async loading.
- * Button callbacks (DrawButtonKDEx) expect sync returns - an async function
- * returns a Promise (always truthy), breaking return value checks.
+ * KinkyDungeonStartNewGame was split into 4 functions to separate sync/async paths.
  *
- * - KinkyDungeonStartNewGame: sync, for new games (called by button callbacks)
+ * - KinkyDungeonStartNewGame: sync, for new games
  * - KinkyDungeonStartNewGameWithLoad: async, for loading saves
  * - KinkyDungeonStartNewGameInit: shared initialization
  * - KinkyDungeonStartNewGameFinalize: shared finalization
@@ -7428,41 +7426,19 @@ async function KDCompressGzip(input: string): Promise<string> {
 	for (let i = 0; i < compressed.length; i++) {
 		binary += String.fromCharCode(compressed[i]);
 	}
+	// return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + btoa(binary);
 	return 'gzip:' + btoa(binary);
 }
 
 /**
  * Decompress a gzip+base64 string (without 'gzip:' prefix)
  */
-async function KDDecompressGzip(base64: string): Promise<string> {
-	const binary = atob(base64);
-	const bytes = new Uint8Array(binary.length);
-	for (let i = 0; i < binary.length; i++) {
-		bytes[i] = binary.charCodeAt(i);
-	}
-
-	const ds = new DecompressionStream('gzip');
-	const writer = ds.writable.getWriter();
-	writer.write(bytes);
-	writer.close();
-
-	const chunks: Uint8Array[] = [];
-	const reader = ds.readable.getReader();
-	while (true) {
-		const {done, value} = await reader.read();
-		if (done) break;
-		chunks.push(value);
-	}
-
-	const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
-	const decompressed = new Uint8Array(totalLen);
-	let offset = 0;
-	for (const chunk of chunks) {
-		decompressed.set(chunk, offset);
-		offset += chunk.length;
-	}
-
-	return new TextDecoder().decode(decompressed);
+async function KDDecompressDataUri(dataUri: string): Promise<string> {
+	// fetch() handles data: URIs natively, decoding base64 for us
+	const res = await fetch(dataUri);
+	const blob = await res.blob();
+	const stream = blob.stream().pipeThrough(new DecompressionStream('gzip'));
+	return new Response(stream).text();
 }
 
 /**
@@ -7476,12 +7452,20 @@ async function KDCompressForSave(json: string): Promise<string> {
 }
 
 /**
- * Decompress save data - auto-detects format (gzip: prefix or LZString)
+ * Decompress save data - auto-detects format:
+ * - 'gzip:' prefix (our format) - translates to data URI
+ * - 'data:' prefix (PR #223 format) - passes directly to fetch
+ * - anything else - legacy LZString
  */
 async function KDDecompressForLoad(data: string): Promise<string> {
 	const trimmed = "".concat(...data.trim().split('\n'));
 	if (trimmed.startsWith('gzip:')) {
-		return KDDecompressGzip(trimmed.slice(5));
+		// Translate our simple format to a data URI
+		return KDDecompressDataUri('data:application/gzip;base64,' + trimmed.slice(5));
+	}
+	if (trimmed.startsWith('data:')) {
+		// Support PR #223 format directly
+		return KDDecompressDataUri(trimmed);
 	}
 	return LZString.decompressFromBase64(trimmed);
 }

--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -1785,6 +1785,8 @@ function KinkyDungeonRun() {
 
 				}
 
+				// Show loading screen before starting async load (but async might not yield, so it might not have time to render)
+				KinkyDungeonState = "GenMap";
 				KDExecuteModsAndStart();
 				// Set the save slot - if the player last loaded a save from slot 2, this will continue saving to slot 2.
 				KDSaveSlot = (localStorage.getItem('KDLastSaveSlot') !== null) ? parseInt(localStorage.getItem('KDLastSaveSlot')) : 0;
@@ -1801,24 +1803,20 @@ function KinkyDungeonRun() {
 				let emptySlot = undefined;
 				for (var i = 1; i <= (saveSlotsPerPage*maxSaveSlotPages); i++) {
 					let num = (i);
-					KinkyDungeonDBLoad(num).then((code) => {
+					KinkyDungeonDBLoad(num).then(async (code) => {
 						loadedsaveslots[num - 1] = code;
-						let decoded = LZString.decompressFromBase64(code);
-						let parse = JSON.parse(decoded);
-						if (decoded && parse?.KDGameData?.PlayerName)
-							loadedsaveNames[num - 1] =
-								JSON.parse(decoded)?.KDGameData?.PlayerName;
-								
-						if (decoded && parse?.KDGameData?.HighestLevelCurrent)
-							loadedsaveFloors[num - 1] =
-								parse.KDGameData.HighestLevelCurrent;
-								
-						if (decoded && parse?.KDGameData?.Class)
-							loadedsaveClasses[num - 1] =
-								parse.KDGameData.Class;
-						if (decoded && (parse?.npp ||  parse?.stats?.npp))
-							loadedsaveNG[num - 1] =
-								(parse?.npp ||  parse?.stats?.npp);
+						if (code) {
+							let decoded = await KDDecompressForLoad(code);
+							let parse = decoded ? JSON.parse(decoded) : null;
+							if (parse?.KDGameData?.PlayerName)
+								loadedsaveNames[num - 1] = parse.KDGameData.PlayerName;
+							if (parse?.KDGameData?.HighestLevelCurrent)
+								loadedsaveFloors[num - 1] = parse.KDGameData.HighestLevelCurrent;
+							if (parse?.KDGameData?.Class)
+								loadedsaveClasses[num - 1] = parse.KDGameData.Class;
+							if (parse?.npp || parse?.stats?.npp)
+								loadedsaveNG[num - 1] = parse?.npp || parse?.stats?.npp;
+						}
 						if (!emptySlot && !code) {
 							emptySlot = num;
 							KDSaveSlot = emptySlot;
@@ -1839,13 +1837,14 @@ function KinkyDungeonRun() {
 				});
 				for (var i = 1; i <= (saveSlotsPerPage*maxSaveSlotPages); i++) {
 					let num = (i);
-					KinkyDungeonDBLoad(num).then((code) => {
+					KinkyDungeonDBLoad(num).then(async (code) => {
 						loadedsaveslots[num - 1] = code;
-
-						let decoded = LZString.decompressFromBase64(code);
-						if (decoded && JSON.parse(decoded)?.KDGameData?.PlayerName)
-							loadedsaveNames[num - 1] =
-								JSON.parse(decoded)?.KDGameData?.PlayerName;
+						if (code) {
+							let decoded = await KDDecompressForLoad(code);
+							if (decoded && JSON.parse(decoded)?.KDGameData?.PlayerName)
+								loadedsaveNames[num - 1] =
+									JSON.parse(decoded)?.KDGameData?.PlayerName;
+						}
 					});
 				}
 
@@ -2886,8 +2885,9 @@ function KinkyDungeonRun() {
 		}
 	} else if (KinkyDungeonState == "Save") {
 		// Draw temp start screen
-		DrawTextKD(TextGet("KinkyDungeonSaveIntro0"), 1250, 350, KDBaseWhite, KDTextGray2);
-		DrawTextKD(TextGet("KinkyDungeonSaveIntro1"), 1250, 475, KDBaseWhite, KDTextGray2);
+		const saveReady = !!ElementValue("saveDataField");
+		DrawTextKD(TextGet(saveReady ? "KinkyDungeonSaveIntro0" : "KDSaving"), 1250, 350, KDBaseWhite, KDTextGray2);
+		if (saveReady) DrawTextKD(TextGet("KinkyDungeonSaveIntro1"), 1250, 475, KDBaseWhite, KDTextGray2);
 		/*DrawTextKD(TextGet("KinkyDungeonSaveIntro"), 1250, 475, KDBaseWhite, KDTextGray2);
 		DrawTextKD(TextGet("KinkyDungeonSaveIntro2"), 1250, 550, KDBaseWhite, KDTextGray2);
 		DrawTextKD(TextGet("KinkyDungeonSaveIntro3"), 1250, 625, KDBaseWhite, KDTextGray2);
@@ -5273,21 +5273,27 @@ function KDDrawLoadMenu() {
 			KDMapData.Grid = "";
 			KinkyDungeonInitialize(1, true);
 			MiniGameKinkyDungeonCheckpoint = "grv";
-			if (KinkyDungeonLoadGame(LoadMenuCurrentSave, KDToggles.OverrideConsent)) {
-				KDGenMapCallback = () => {
-					if (KDMapData.Grid == "")
-						KinkyDungeonCreateMap(KinkyDungeonMapParams[(KinkyDungeonMapIndex[MiniGameKinkyDungeonCheckpoint] || MiniGameKinkyDungeonCheckpoint)],
-							KDMapData.RoomType || "", KDMapData.MapMod || "", MiniGameKinkyDungeonLevel, false, true);
-					KinkyDungeonState = "Game";
-					if (KinkyDungeonKeybindings) {
-						KDCommitKeybindings();
-					}
-					KDModsAfterGameStart();
-					return "Game";
-				};
-				KinkyDungeonState = "GenMap";
-
-			}
+			// Show loading screen immediately, async load sets callback when done
+			KinkyDungeonState = "GenMap";
+			const saveData = LoadMenuCurrentSave;
+			KinkyDungeonLoadGame(saveData, KDToggles.OverrideConsent).then(success => {
+				if (success && KinkyDungeonState == "GenMap") {
+					KDGenMapCallback = () => {
+						if (KDMapData.Grid == "")
+							KinkyDungeonCreateMap(KinkyDungeonMapParams[(KinkyDungeonMapIndex[MiniGameKinkyDungeonCheckpoint] || MiniGameKinkyDungeonCheckpoint)],
+								KDMapData.RoomType || "", KDMapData.MapMod || "", MiniGameKinkyDungeonLevel, false, true);
+						KinkyDungeonState = "Game";
+						if (KinkyDungeonKeybindings) {
+							KDCommitKeybindings();
+						}
+						KDModsAfterGameStart();
+						return "Game";
+					};
+				} else if (KinkyDungeonState == "GenMap") {
+					// Load failed, return to menu
+					KinkyDungeonState = "Menu";
+				}
+			});
 			LoadMenuCurrentSave = undefined;
 			LoadMenuCurrentSlot = undefined;
 			ElementRemove("saveInputField");
@@ -5760,32 +5766,50 @@ function KinkyDungeonLoadPreview(String: string): KinkyDungeonSave {
 	}
 }
 
-function KinkyDungeonStartNewGame(Load: boolean = false) {
+/**
+ * KinkyDungeonStartNewGame was split into 4 functions to isolate async loading.
+ * Button callbacks (DrawButtonKDEx) expect sync returns - an async function
+ * returns a Promise (always truthy), breaking return value checks.
+ *
+ * - KinkyDungeonStartNewGame: sync, for new games (called by button callbacks)
+ * - KinkyDungeonStartNewGameWithLoad: async, for loading saves
+ * - KinkyDungeonStartNewGameInit: shared initialization
+ * - KinkyDungeonStartNewGameFinalize: shared finalization
+ */
+function KinkyDungeonStartNewGameInit(Load: boolean) {
 	KinkyDungeonSendEvent("beforeNewGame", {Load: Load});
 	KinkyDungeonNewGame = 0;
-	let cp = KinkyDungeonMapIndex.grv;
 	KDUpdateHardMode();
 	KinkyDungeonInitialize(1, Load);
 	MiniGameKinkyDungeonCheckpoint = "grv";
 	KDMapData.Grid = "";
-	if (Load) {
-		KinkyDungeonLoadGame(undefined, true);
-		KDSendEvent('loadGame');
-	} else {
-		KDSendEvent('newGame');
-		KDGameData.RoomType = "JourneyFloor";//KinkyDungeonStatsChoice.get("easyMode") ? "ShopStart" : "JourneyFloor";
-		KDSetWorldSlot(0, 0, 0, 0);
-		KDInitializeJourney("");
+}
 
+function KinkyDungeonStartNewGame() {
+	let cp = KinkyDungeonMapIndex.grv;
+	KinkyDungeonStartNewGameInit(false);
+	KDSendEvent('newGame');
+	KDGameData.RoomType = "JourneyFloor";
+	KDSetWorldSlot(0, 0, 0, 0);
+	KDInitializeJourney("");
 
-
-		if (KDTileToTest) {
-			KinkyDungeonMapIndex.grv = cp;
-		}
-
-		KDGameData.PlayerName = localStorage.getItem("PlayerName") || "Ada";
-		KinkyDungeonPlayer.Name = KDGameData.PlayerName;
+	if (KDTileToTest) {
+		KinkyDungeonMapIndex.grv = cp;
 	}
+
+	KDGameData.PlayerName = localStorage.getItem("PlayerName") || "Ada";
+	KinkyDungeonPlayer.Name = KDGameData.PlayerName;
+	KinkyDungeonStartNewGameFinalize(false);
+}
+
+async function KinkyDungeonStartNewGameWithLoad() {
+	KinkyDungeonStartNewGameInit(true);
+	await KinkyDungeonLoadGame("", KDToggles.OverrideConsent);
+	KDSendEvent('loadGame');
+	KinkyDungeonStartNewGameFinalize(true);
+}
+
+function KinkyDungeonStartNewGameFinalize(Load: boolean) {
 	if (!KDMapData.Grid) {
 		KinkyDungeonCreateMap(KinkyDungeonMapParams[(KinkyDungeonMapIndex[MiniGameKinkyDungeonCheckpoint] || MiniGameKinkyDungeonCheckpoint)], "JourneyFloor", "", MiniGameKinkyDungeonLevel, false, Load);
 		KDInitPerks();
@@ -5796,8 +5820,6 @@ function KinkyDungeonStartNewGame(Load: boolean = false) {
 		KDCommitKeybindings();
 	}
 	if (KDSoundEnabled()) AudioPlayInstantSoundKD(KinkyDungeonRootDirectory + "Audio/StoneDoor_Close.ogg");
-
-
 
 	KDModsAfterGameStart();
 	if (!Load)
@@ -6027,18 +6049,27 @@ function KinkyDungeonHandleClick(event: MouseEvent) {
 				KinkyDungeonConfigAppearance = false;
 			KinkyDungeonInitialize(1, true);
 			MiniGameKinkyDungeonCheckpoint = "grv";
-			if (KinkyDungeonLoadGame(ElementValue("saveInputField"), KDToggles.OverrideConsent)) {
-				KDSendEvent('loadGame');
-				//KDInitializeJourney(KDJourney);
-				if (KDMapData.Grid == "") KinkyDungeonCreateMap(KinkyDungeonMapParams[(KinkyDungeonMapIndex[MiniGameKinkyDungeonCheckpoint] || MiniGameKinkyDungeonCheckpoint)], KDMapData.RoomType || "", KDMapData.MapMod || "", MiniGameKinkyDungeonLevel, false, true);
-				ElementRemove("saveInputField");
-				KinkyDungeonState = "Game";
-
-				if (KinkyDungeonKeybindings) {
-					KDCommitKeybindings();
+			// Show loading screen immediately, async load sets callback when done
+			const saveData = ElementValue("saveInputField");
+			ElementRemove("saveInputField");
+			KinkyDungeonState = "GenMap";
+			KinkyDungeonLoadGame(saveData, KDToggles.OverrideConsent).then(success => {
+				if (success && KinkyDungeonState == "GenMap") {
+					KDGenMapCallback = () => {
+						KDSendEvent('loadGame');
+						if (KDMapData.Grid == "") KinkyDungeonCreateMap(KinkyDungeonMapParams[(KinkyDungeonMapIndex[MiniGameKinkyDungeonCheckpoint] || MiniGameKinkyDungeonCheckpoint)], KDMapData.RoomType || "", KDMapData.MapMod || "", MiniGameKinkyDungeonLevel, false, true);
+						KinkyDungeonState = "Game";
+						if (KinkyDungeonKeybindings) {
+							KDCommitKeybindings();
+						}
+						KDModsAfterGameStart();
+						return "Game";
+					};
+				} else if (KinkyDungeonState == "GenMap") {
+					// Load failed, return to menu
+					KinkyDungeonState = "Menu";
 				}
-				KDModsAfterGameStart();
-			}
+			});
 			return true;
 		}
 	} else if (KinkyDungeonState == "LoadOutfit"){
@@ -6772,7 +6803,7 @@ async function KinkyDungeonCompressSave(save: string): Promise<string> {
 				console.log('Compressed data received from worker');
 				resolve(e.data);
 			}
-			myWorker.postMessage(save);
+			myWorker.postMessage({save: save, useGzip: KDToggles.NativeCompression});
 			console.log('Save message posted to worker');
 			setTimeout(reject, KDSaveTimeout); // 10 min timeout
 		});
@@ -6784,20 +6815,25 @@ async function KinkyDungeonCompressSave(save: string): Promise<string> {
 			.catch((v) => {
 				console.log('Nay');
 				myWorker.terminate();
-				return LZString.compressToBase64(save);});
+				return KDCompressForSave(save);});
 	} else {
 		console.log('Your browser doesn\'t support web workers.');
-		return LZString.compressToBase64(save);
+		return KDCompressForSave(save);
 	}
 }
 
 // N4IgNgpgbhYgXARgDQgMYAsJoNYAcB7ASwDsAXBABlQCcI8FQBxDAgZwvgFoBWakAAo0ibAiQg0EvfgBkIAQzJZJ8fgFkIZeXFWoASgTwQqqAOpEwO/gFFIAWwjk2JkAGExAKwCudFwElLLzYiMSoAX1Q0djJneGAIkAIaACNYgG0AXUisDnSskAATOjZYkAARCAAzeS8wClQAcwIwApdCUhiEAGZUSBgwWNBbCAcnBBQ3Tx9jJFQAsCCQknGEtiNLPNRSGHIkgE8ENNAokjYvO3lkyEYQEnkHBEECMiW1eTuQBIBHL3eXsgOSAixzEZwuVxmoDuD3gTxeYgAylo7KR5J9UD8/kQAStkCDTudLtc4rd7jM4UsAGLCBpEVrfX7kbGAxDAkAAdwUhGWJOh5IA0iQiJVjGE2cUyDR5B0bnzHmUvGgyAAVeRGOQNZwJF4NDBkcQlca9Ai4R7o0ASqUy3lk+WKlVqiCUiCaNTnOwHbVEXX6iCG2bgE04M1hDJhIA=
-function KinkyDungeonLoadGame(String: string = "", kdloadconsent = false) {
+async function KinkyDungeonLoadGame(String: string = "", kdloadconsent = false): Promise<boolean> {
 	localStorage.setItem('KDLastSaveSlot', "" + KDSaveSlot);
 	KinkyDungeonSendEvent("beforeLoadGame", {});
-	let str = String ? DecompressB64(String.trim()) :
-		(localStorage.getItem('KinkyDungeonSave') ? DecompressB64(localStorage.getItem('KinkyDungeonSave'))
-		: (loadedsaveslots[KDSaveSlot-1] ? DecompressB64(loadedsaveslots[KDSaveSlot-1]) : ""));
+	let str = "";
+	if (String) {
+		str = await KDDecompressForLoad(String.trim());
+	} else if (localStorage.getItem('KinkyDungeonSave')) {
+		str = await KDDecompressForLoad(localStorage.getItem('KinkyDungeonSave'));
+	} else if (loadedsaveslots[KDSaveSlot-1]) {
+		str = await KDDecompressForLoad(loadedsaveslots[KDSaveSlot-1]);
+	}
 	if (str) {
 		let saveData: KinkyDungeonSave = JSON.parse(str);
 		if (    saveData
@@ -7357,6 +7393,98 @@ function KDDrawGameSetupTabs(_xOffset: number = 500, xpad: number = 10, num: num
 }
 
 
+
+/**
+ * Compress a string using native browser gzip, returns 'gzip:' + base64
+ */
+async function KDCompressGzip(input: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const inputBytes = encoder.encode(input);
+
+	const cs = new CompressionStream('gzip');
+	const writer = cs.writable.getWriter();
+	writer.write(inputBytes);
+	writer.close();
+
+	const chunks: Uint8Array[] = [];
+	const reader = cs.readable.getReader();
+	while (true) {
+		const {done, value} = await reader.read();
+		if (done) break;
+		chunks.push(value);
+	}
+
+	// Combine chunks
+	const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
+	const compressed = new Uint8Array(totalLen);
+	let offset = 0;
+	for (const chunk of chunks) {
+		compressed.set(chunk, offset);
+		offset += chunk.length;
+	}
+
+	// Convert to base64
+	let binary = '';
+	for (let i = 0; i < compressed.length; i++) {
+		binary += String.fromCharCode(compressed[i]);
+	}
+	return 'gzip:' + btoa(binary);
+}
+
+/**
+ * Decompress a gzip+base64 string (without 'gzip:' prefix)
+ */
+async function KDDecompressGzip(base64: string): Promise<string> {
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+
+	const ds = new DecompressionStream('gzip');
+	const writer = ds.writable.getWriter();
+	writer.write(bytes);
+	writer.close();
+
+	const chunks: Uint8Array[] = [];
+	const reader = ds.readable.getReader();
+	while (true) {
+		const {done, value} = await reader.read();
+		if (done) break;
+		chunks.push(value);
+	}
+
+	const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
+	const decompressed = new Uint8Array(totalLen);
+	let offset = 0;
+	for (const chunk of chunks) {
+		decompressed.set(chunk, offset);
+		offset += chunk.length;
+	}
+
+	return new TextDecoder().decode(decompressed);
+}
+
+/**
+ * Compress save data for export - async, uses gzip if toggle enabled
+ */
+async function KDCompressForSave(json: string): Promise<string> {
+	if (KDToggles.NativeCompression && typeof CompressionStream !== 'undefined') {
+		return KDCompressGzip(json);
+	}
+	return LZString.compressToBase64(json);
+}
+
+/**
+ * Decompress save data - auto-detects format (gzip: prefix or LZString)
+ */
+async function KDDecompressForLoad(data: string): Promise<string> {
+	const trimmed = "".concat(...data.trim().split('\n'));
+	if (trimmed.startsWith('gzip:')) {
+		return KDDecompressGzip(trimmed.slice(5));
+	}
+	return LZString.decompressFromBase64(trimmed);
+}
 
 function DecompressB64(str: string): string {
 	if (!str || !str.trim) return str;

--- a/Game/src/base/game/KinkyDungeonHUD.ts
+++ b/Game/src/base/game/KinkyDungeonHUD.ts
@@ -1905,11 +1905,18 @@ function KinkyDungeonHandleHUD() {
 				return true;
 			}
 			if (MouseIn(1500, 320, 300, 64)) {
-				let saveData = LZString.compressToBase64(JSON.stringify(KinkyDungeonSaveGame(true)));
 				KinkyDungeonState = "Save";
 				ElementCreateTextArea("saveDataField");
-				ElementValue("saveDataField", saveData);
+				const textarea = document.getElementById("saveDataField") as HTMLTextAreaElement;
+				if (textarea) textarea.readOnly = true;
+				ElementValue("saveDataField", "");
 
+				const saveJson = JSON.stringify(KinkyDungeonSaveGame(true));
+				KDCompressForSave(saveJson).then(saveData => {
+					if (KinkyDungeonState == "Save") {
+						ElementValue("saveDataField", saveData);
+					}
+				});
 
 				return true;
 			}

--- a/Game/src/map/KDStairActions.ts
+++ b/Game/src/map/KDStairActions.ts
@@ -251,15 +251,23 @@ function KDGoThruTile(x: number, y: number, suppressCheckPoint: boolean, force: 
 
 function KDPostStairSave() {
 	if (KDGameData.RoomType == "PerkRoom" && MiniGameKinkyDungeonLevel >= 1) { //  && Math.floor(MiniGameKinkyDungeonLevel / 3) == MiniGameKinkyDungeonLevel / 3
-			if ((!KinkyDungeonStatsChoice.get("saveMode"))) {
-				let saveData = LZString.compressToBase64(JSON.stringify(KinkyDungeonSaveGame(true)));
-				KinkyDungeonState = "Save";
-				KDTextArea("saveDataField", 750, 100, 1000, 230);
-				ElementValue("saveDataField", saveData);
-			} else KinkyDungeonSaveGame();
-		}
-		else KinkyDungeonSaveGame();
- }
+		if ((!KinkyDungeonStatsChoice.get("saveMode"))) {
+			KinkyDungeonState = "Save";
+			KDTextArea("saveDataField", 750, 100, 1000, 230);
+			const textarea = document.getElementById("saveDataField") as HTMLTextAreaElement;
+			if (textarea) textarea.readOnly = true;
+			ElementValue("saveDataField", "");
+
+			const saveJson = JSON.stringify(KinkyDungeonSaveGame(true));
+			KDCompressForSave(saveJson).then(saveData => {
+				if (KinkyDungeonState == "Save") {
+					ElementValue("saveDataField", saveData);
+				}
+			});
+		} else KinkyDungeonSaveGame();
+	} else KinkyDungeonSaveGame();
+}
+
 function KinkyDungeonHandleStairs(toTile: string, suppressCheckPoint?: boolean) {
 	if (KinkyDungeonFlags.get("stairslocked")) {
 		KinkyDungeonSendActionMessage(10, TextGet("KDStairsLocked").replace("NMB", "" + KinkyDungeonFlags.get("stairslocked")), KDBaseWhite, 1);

--- a/Game/src/player/KinkyDungeonVibe.ts
+++ b/Game/src/player/KinkyDungeonVibe.ts
@@ -179,6 +179,7 @@ let KDToggles = {
 	ExtraTooltipCycle: true,
 	ShowExtraStruggle: false,
 	InvLimit: true,
+	NativeCompression: false,
 	Headpats: false,
 	ExtraBuffRow: true,
 	StruggleContext: false,
@@ -279,6 +280,7 @@ let KDToggleCategories = {
 	HideArmorWardrobe: "none",
 	BindPercent: "UI",
 	AutoWaitDelayed: "UI",
+	NativeCompression: "Main",
 };
 
 function KDStopAllVibeSounds(Exceptions?: string[]) {

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -77,6 +77,7 @@ KDToggleApplyPaletteRestraint,Apply palettes to Restraints
 KDToggleApplyPaletteTransform,Apply palettes to transforms
 
 KDToggleInvLimit,(Test) Enforce Inventory Limits
+KDToggleNativeCompression,Native Browser Save Compression
 KDToggleIgnoreApplyCharPalette,Don't use character palette
 KDToggleAlwaysApplyCharPalette,Always use character palette
 KDToggleDefaultApplyCharPalette,Use character palette for default outfit

--- a/Scripts/KDMods.ts
+++ b/Scripts/KDMods.ts
@@ -255,7 +255,7 @@ async function KDExecuteModsAndStart() {
 
 	if (!KDToggles.OverrideOutfit)
 		KinkyDungeonConfigAppearance = false;
-	KinkyDungeonStartNewGame(true);
+	await KinkyDungeonStartNewGameWithLoad();
 }
 
 /** Updates mod info by unzipping mods and reading the info only */

--- a/out/saveworker.js
+++ b/out/saveworker.js
@@ -1,8 +1,48 @@
 // eslint-disable-next-line strict
 importScripts('../Scripts/lib/LZString.js');
 
-onmessage = (e) => {
+async function compressGzip(input) {
+	const encoder = new TextEncoder();
+	const inputBytes = encoder.encode(input);
+
+	const cs = new CompressionStream('gzip');
+	const writer = cs.writable.getWriter();
+	writer.write(inputBytes);
+	writer.close();
+
+	const chunks = [];
+	const reader = cs.readable.getReader();
+	while (true) {
+		const {done, value} = await reader.read();
+		if (done) break;
+		chunks.push(value);
+	}
+
+	const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
+	const compressed = new Uint8Array(totalLen);
+	let offset = 0;
+	for (const chunk of chunks) {
+		compressed.set(chunk, offset);
+		offset += chunk.length;
+	}
+
+	let binary = '';
+	for (let i = 0; i < compressed.length; i++) {
+		binary += String.fromCharCode(compressed[i]);
+	}
+	return 'gzip:' + btoa(binary);
+}
+
+onmessage = async (e) => {
 	console.log("Compressing save in worker thread...");
-	postMessage(LZString.compressToBase64(e.data));
+	// Support both old format (string) and new format ({save, useGzip})
+	const data = typeof e.data === 'string' ? e.data : e.data.save;
+	const useGzip = typeof e.data === 'string' ? false : e.data.useGzip;
+
+	if (useGzip && typeof CompressionStream !== 'undefined') {
+		postMessage(await compressGzip(data));
+	} else {
+		postMessage(LZString.compressToBase64(data));
+	}
 	close();
 };

--- a/out/saveworker.js
+++ b/out/saveworker.js
@@ -26,7 +26,18 @@ async function compressGzip(input) {
 		offset += chunk.length;
 	}
 
-	return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + compressed.toBase64();
+	// Use toBase64() where available (Chrome 137+), fall back to btoa for older engines
+	let b64;
+	if (typeof compressed.toBase64 === 'function') {
+		b64 = compressed.toBase64();
+	} else {
+		let binary = '';
+		for (let i = 0; i < compressed.length; i++) {
+			binary += String.fromCharCode(compressed[i]);
+		}
+		b64 = btoa(binary);
+	}
+	return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + b64;
 }
 
 onmessage = async (e) => {

--- a/out/saveworker.js
+++ b/out/saveworker.js
@@ -30,6 +30,7 @@ async function compressGzip(input) {
 	for (let i = 0; i < compressed.length; i++) {
 		binary += String.fromCharCode(compressed[i]);
 	}
+	// return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + btoa(binary);
 	return 'gzip:' + btoa(binary);
 }
 

--- a/out/saveworker.js
+++ b/out/saveworker.js
@@ -26,12 +26,7 @@ async function compressGzip(input) {
 		offset += chunk.length;
 	}
 
-	let binary = '';
-	for (let i = 0; i < compressed.length; i++) {
-		binary += String.fromCharCode(compressed[i]);
-	}
-	// return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + btoa(binary);
-	return 'gzip:' + btoa(binary);
+	return 'data:application/vnd.straightlaced.kinkydungeon.save.game+gzip;version=2;base64,' + compressed.toBase64();
 }
 
 onmessage = async (e) => {


### PR DESCRIPTION
This uses the native CompressionStream (async pain in the ass) instead of doing compression in pure js.

It's 10 times faster, and surprisingly, a bit smaller.

I don't think I made too much of a mess with async, but it's not as clean as I'd like.