### PR TITLE
Automatic inventory filter for "CMD: Unlock"

### DIFF
--- a/Game/src/base/KDTypeDefs.ts
+++ b/Game/src/base/KDTypeDefs.ts
@@ -2802,6 +2802,8 @@ interface KDInventoryActionDef {
 	hotkey?: () => string,
 	hotkeyPress?: () => string,
 	alsoShow?: string[],
+	/** Auto-filter inventory items when this action is active */
+	autoFilter?: (item: item) => boolean,
 }
 
 interface KinkyDungeonSave {

--- a/Game/src/item/KDInventoryActions.ts
+++ b/Game/src/item/KDInventoryActions.ts
@@ -698,6 +698,9 @@ let KDInventoryAction: Record<string, KDInventoryActionDef> = {
 			if (!(item?.type == Restraint)) return false;
 			return KDMagicLocks.includes(item.lock);
 		},
+		autoFilter: (item) => {
+			return KDMagicLocks.includes(item.lock);
+		},
 		/** Happens when you click the button */
 		click: (_player, item) => {
 			if (KDMagicLocks.includes(item.lock)) {

--- a/Game/src/item/KinkyDungeonInventory.ts
+++ b/Game/src/item/KinkyDungeonInventory.ts
@@ -1018,6 +1018,11 @@ function KinkyDungeonFilterInventory(Filter: string, enchanted?: boolean, ignore
 				}
 			}
 
+			// Auto-filter from inventory action
+			if (KDGameData.InventoryAction && KDInventoryAction[KDGameData.InventoryAction]?.autoFilter) {
+				if (!KDInventoryAction[KDGameData.InventoryAction].autoFilter(item)) continue;
+			}
+
 			let preview = KDGetItemPreview(item);
 			//let pre = (item.type == LooseRestraint || item.type == Restraint) ? "Restraint" : "KinkyDungeonInventoryItem";
 			if (preview


### PR DESCRIPTION
This is a small change. Provide an autoFilter callback to inventory actions. If exists, inventory display will apply that filter.

It can easily be extended to other target specific actions.