### PR TITLE
Deduplicate "the" in dialog.

### DIFF
--- a/Game/src/dialogue/KinkyDungeonDialogue.ts
+++ b/Game/src/dialogue/KinkyDungeonDialogue.ts
@@ -126,7 +126,17 @@ function KDDrawDialogue(delta: number): void {
 						tt = tt.replace(d[0], d[1]);
 					}
 				}
-				DrawTextFitKD(tt.replace("SPEAKER", TextGet("Name" + KDGameData.CurrentDialogMsgSpeaker)),
+				/*  Try to eliminate any redundant "the".  */
+				const npc_name = TextGet ("Name" + KDGameData.CurrentDialogMsgSpeaker);
+				const re_the_npc = /^[Tt]he\s+/;	// Anchored to beginning of string.
+				if (re_the_npc.test (npc_name)) {
+					/*
+					 * NPC name starts with "The ".  Chop out redundant "A " or "The "
+					 * from dialog, if present.
+					 */
+					tt = tt.replace (/\b(?:[Aa]|[Tt]he)\s+SPEAKER/, "SPEAKER");
+				}
+				DrawTextFitKD (tt.replace ("SPEAKER", npc_name),
 					1000, 300 + 50 * i - 25 * text.length, 900, KDBaseWhite, "black", undefined, undefined, 115);
 			}
 


### PR DESCRIPTION
Try to avoid what I amuse myself by calling the "Attack of the The Eye Creatures" problem.  When interacting with NPCs whose names start with "The" (The Executive, The Shadow, etc.), try to eliminate any immediately preceding "the" or "a" in the dialog string.

Note this is a *very* cheap approach, and doesn't work in all cases. For example, "A SPEAKER approaches" will be altered to "SPEAKER approaches", which will then expand to "The Executive approaches". However, "A happy SPEAKER approaches" will not be modified, and will come out saying, "A happy The Executive approaches."