### PR TITLE
Add padding to the culled choice list.

### DIFF
--- a/Game/src/base/game/KinkyDungeonHUD.ts
+++ b/Game/src/base/game/KinkyDungeonHUD.ts
@@ -2256,6 +2256,12 @@ function KDCullSpellChoices() {
 		KinkyDungeonArmorChoices = KinkyDungeonArmorChoices.slice(0, KinkyDungeonSpellChoiceCount);
 	if (KinkyDungeonConsumableChoices.length >= KinkyDungeonSpellChoiceCount)
 		KinkyDungeonConsumableChoices = KinkyDungeonConsumableChoices.slice(0, KinkyDungeonSpellChoiceCount);
+	const max_choices = Math.max (KinkyDungeonSpellChoices.length, KinkyDungeonConsumableChoices.length, KinkyDungeonWeaponChoices.length, KinkyDungeonArmorChoices.length)
+	const padded_choices = Math.ceil(max_choices / KinkyDungeonSpellChoiceCountPerPage) * KinkyDungeonSpellChoiceCountPerPage
+	KinkyDungeonSpellChoices.length = padded_choices
+	KinkyDungeonWeaponChoices.length = padded_choices
+	KinkyDungeonArmorChoices.length = padded_choices
+	KinkyDungeonConsumableChoices.length = padded_choices
 }
 
 let currentHighlightedItem: item = null;


### PR DESCRIPTION
Currently if the last entry of the last page of the hotbar is not populated, the primary hotbar button does not work (hotkey works, clicking doesn't), and the other pages are rendered weirdly. This PR fixes that.