### PR TITLE
Add static analysis tool for custom type validation

### DIFF
--- a/Game/src/base/KDTypeDefs.ts
+++ b/Game/src/base/KDTypeDefs.ts
@@ -1,3 +1,7 @@
+/* Static analysis typedefs - define checks in tools/type-validators.ts
+	To run analysis, exec: npx tsx tools/static-analysis.ts */
+type HexColor = string;
+
 type Named = {
 	name: string,
 	inventoryVariant?: string,
@@ -144,7 +148,7 @@ interface consumable extends NamedAndTyped {
 	power?: number,
 	amount?: number,
 	rechargeCost?: number,
-	aura?: string,
+	aura?: HexColor,
 	buff?: string,
 	costMod?: number,
 	shrine?: string,
@@ -1765,7 +1769,7 @@ interface KDBuff {
 	type?: string,
 	duration?: number,
 	infinite?: boolean,
-	aura?: string,
+	aura?: HexColor,
 	range?: number,
 	currentCount?: number,
 	maxCount?: number,
@@ -4034,7 +4038,7 @@ interface KDSeal {
 	/** Name of the seal buff */
 	name: string,
 	/** Color of the seal buff */
-	aura: string,
+	aura: HexColor,
 	/** Sprite of the seal buff */
 	aurasprite: string,
 	/** Events of the seal buff */

--- a/tools/static-analysis.ts
+++ b/tools/static-analysis.ts
@@ -1,0 +1,114 @@
+import * as ts from 'typescript';
+import * as path from 'path';
+import { typeValidators } from './type-validators';
+
+// --- Framework ---
+
+interface Diagnostic {
+	file: string;
+	line: number;
+	col: number;
+	message: string;
+}
+
+const diagnostics: Diagnostic[] = [];
+
+// --- Core Logic ---
+
+/**
+ * Given a property assignment node, resolve the declared type annotation name
+ * from the interface/type definition (not the resolved type, which would just be "string").
+ */
+function getDeclaredTypeAliasName(prop: ts.PropertyAssignment, checker: ts.TypeChecker): string | undefined {
+	const objectLiteral = prop.parent;
+	if (!ts.isObjectLiteralExpression(objectLiteral)) return undefined;
+
+	const contextualType = checker.getContextualType(objectLiteral);
+	if (!contextualType) return undefined;
+
+	const propName = prop.name.getText();
+	const propSymbol = contextualType.getProperty(propName);
+	if (!propSymbol) return undefined;
+
+	// Walk to the declaration to read the type annotation text
+	const decl = propSymbol.declarations?.[0];
+	if (!decl) return undefined;
+
+	// Property signature: `aura?: HexColor`
+	if (ts.isPropertySignature(decl) && decl.type) {
+		return decl.type.getText();
+	}
+	// Property declaration: `aura: HexColor`
+	if (ts.isPropertyDeclaration(decl) && decl.type) {
+		return decl.type.getText();
+	}
+
+	return undefined;
+}
+
+function visitNode(node: ts.Node, checker: ts.TypeChecker, sourceFile: ts.SourceFile, relPath: string) {
+	// Only care about string literals inside property assignments
+	if (ts.isStringLiteral(node)) {
+		const parent = node.parent;
+		if (parent && ts.isPropertyAssignment(parent) && parent.initializer === node) {
+			const typeName = getDeclaredTypeAliasName(parent, checker);
+			if (typeName) {
+				const validator = typeValidators[typeName];
+				if (validator && !validator.validate(node.text)) {
+					const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+					diagnostics.push({
+						file: relPath,
+						line: line + 1,
+						col: character + 1,
+						message: `Invalid ${typeName} "${node.text}" — expected ${validator.expected}`,
+					});
+				}
+			}
+		}
+	}
+
+	ts.forEachChild(node, child => visitNode(child, checker, sourceFile, relPath));
+}
+
+// --- Runner ---
+
+function run() {
+	const projectDir = path.resolve(__dirname, '..');
+	const configPath = ts.findConfigFile(projectDir, ts.sys.fileExists, 'tsconfig.json');
+	if (!configPath) {
+		console.error('Could not find tsconfig.json');
+		process.exit(1);
+	}
+
+	const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+	if (configFile.error) {
+		console.error('Error reading tsconfig.json:', ts.flattenDiagnosticMessageText(configFile.error.messageText, '\n'));
+		process.exit(1);
+	}
+
+	const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, projectDir);
+	const program = ts.createProgram(parsed.fileNames, parsed.options);
+	const checker = program.getTypeChecker();
+
+	for (const sourceFile of program.getSourceFiles()) {
+		if (sourceFile.isDeclarationFile) continue;
+		if (sourceFile.fileName.includes('node_modules')) continue;
+
+		const relPath = path.relative(projectDir, sourceFile.fileName);
+		visitNode(sourceFile, checker, sourceFile, relPath);
+	}
+
+	if (diagnostics.length === 0) {
+		console.log('static-analysis: no issues found');
+		process.exit(0);
+	}
+
+	for (const d of diagnostics) {
+		console.log(`${d.file}:${d.line}:${d.col} - ${d.message}`);
+	}
+
+	console.log(`\nFound ${diagnostics.length} issue(s)`);
+	process.exit(1);
+}
+
+run();

--- a/tools/type-validators.ts
+++ b/tools/type-validators.ts
@@ -1,0 +1,19 @@
+// Maps custom type alias names to validation callbacks.
+// The static analysis tool resolves the declared type annotation of each
+// string literal's target property and runs the matching validator.
+//
+// Add new entries here to extend validation to other custom types.
+
+export interface TypeValidator {
+	/** Regex or function that checks the literal value */
+	validate: (value: string) => boolean;
+	/** Human-readable expectation for error messages */
+	expected: string;
+}
+
+export const typeValidators: Record<string, TypeValidator> = {
+	HexColor: {
+		validate: (v) => /^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?([0-9a-fA-F]{2})?$/.test(v),
+		expected: '#RGB, #RRGGBB, or #RRGGBBAA',
+	},
+};

--- a/tools/type-validators.ts
+++ b/tools/type-validators.ts
@@ -13,7 +13,7 @@ export interface TypeValidator {
 
 export const typeValidators: Record<string, TypeValidator> = {
 	HexColor: {
-		validate: (v) => /^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?([0-9a-fA-F]{2})?$/.test(v),
+		validate: (v) => /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(v),
 		expected: '#RGB, #RRGGBB, or #RRGGBBAA',
 	},
 };


### PR DESCRIPTION
TypeScript aliases like `type HexColor = string` are invisible to tsc - it just sees string. This tool uses the TS compiler API to resolve the declared type annotation name from interface definitions, then runs matching validators from tools/type-validators.ts against string literals.

To add a new validated type:
1. Define `type Foo = string` in KDTypeDefs.ts and use it on properties
2. Add a Foo entry in tools/type-validators.ts with a regex/callback

Run with: npx tsx tools/static-analysis.ts