### PR TITLE
KinkyDungeonShrine Text rendering

### DIFF
--- a/Game/src/base/game/KinkyDungeonDraw.ts
+++ b/Game/src/base/game/KinkyDungeonDraw.ts
@@ -3201,6 +3201,7 @@ function DrawTextFitKDgetHeight(
 	font?:		string,
 	wordwrap: 	boolean = false,
 	valign?: 	string,
+	lineHeight?: number,
 ): number {
 	//does the job of both DrawTextFitKD and DrawTextFitKDTo because editing the output of DrawTextFitKDTo would lead to a lot of changes
 	if (!Text) return 0;
@@ -3221,7 +3222,8 @@ function DrawTextFitKDgetHeight(
 		unique: unique,
 		font: font,
 		wordwrap: wordwrap,
-		valign: valign
+		valign: valign,
+		lineHeight: lineHeight
 	})[1];//return the height
 }
 
@@ -3241,6 +3243,7 @@ type TextParamsType = {
 	font?:     string,
 	wordwrap?: boolean,
 	valign?: 	string,
+	lineHeight?: number,
 }
 
 /**
@@ -3444,7 +3447,8 @@ function DrawTextVisKD (Container: PIXIContainer, Map: Map<string, any>, id: str
 				padding: 5,
 				wordWrap: Params.wordwrap,
 				wordWrapWidth: Params.Width,
-				breakWords: Params.wordwrap && CharacterCheckerHasCJK(Params.Text) // Ensure that CJK characters can wrap word.
+				breakWords: Params.wordwrap && CharacterCheckerHasCJK(Params.Text), // Ensure that CJK characters can wrap word.
+				lineHeight: Params.lineHeight,
 			}
 		);
 

--- a/Game/src/map/KinkyDungeonShrine.ts
+++ b/Game/src/map/KinkyDungeonShrine.ts
@@ -999,51 +999,26 @@ function KinkyDungeonDrawPerkOrb() {
                 let perkraritycolor = KDGetPerkRarityColor(KinkyDungeonStatsPresets[p].cost)
 				
                 DrawTextFitKD(TextGet("KinkyDungeonStat" + KinkyDungeonStatsPresets[p].id), KDModalArea_x + (360 * i) + 25, textoffset, 300, perkraritycolor, (KinkyDungeonStatsPresets[p].cost < 0) ? KDTextRed1: KDTextGray2, 30, "left");
-                textoffset += 30
+                textoffset += 20
 				let perktext = TextGet("KinkyDungeonStatDesc" + KinkyDungeonStatsPresets[p].id);
-				let perktextHasCJK = CharacterCheckerHasCJK(perktext);
-				let perktextsplits = [];
-				let perktextheight = 0;
-				if (perktextHasCJK) {
-					// Pixi can wrap CJK text character by character when word wrapping is enabled.
-					perktextheight = DrawTextFitKDgetHeight(perktext,
-						KDModalArea_x + (360 * i) + 30, textoffset, 300,
-						KDBaseWhite, KDTextGray2, 16, "left", 110, 1.0,
-						undefined, undefined, undefined, true, "top") + 20;
-				} else {
-					perktextsplits = perktext.split(" ");
-					perktextsplits = perktextsplits.reduce((prev, currword) => {
-						let currentlength = prev[prev.length - 1].length;
-						if ((currentlength + currword.length + 1) > 36 && (currentlength > 0)) {
-							prev.push(currword)
-						}
-						else {
-							prev[prev.length - 1] = (currentlength > 0) ? `${prev[prev.length - 1]} ${currword}` : currword
-						}
-						return prev;
-					}, ['']);
-					perktextheight = perktextsplits.length * 25;
-				}
+				// Pixi wraps both word-separated and CJK text when word wrapping is enabled.
+				let perktextheight = DrawTextFitKDgetHeight(perktext,
+					KDModalArea_x + (360 * i) + 30, textoffset, 300,
+					KDBaseWhite, KDTextGray2, 16, "left", 110, 1.0,
+					undefined, undefined, undefined, true, "top", 22) + 20;
 				if (KinkyDungeonStatsPresets[p].cost < 0) {
 					FillRectKD(kdcanvas, kdpixisprites, `bg_${i}_debuffperk_${p}`, {
 						Left: KDModalArea_x + (360 * i) + 10,
-						Top: textoffset - 55,
+						Top: textoffset - 45,
 						Width: 330,
-						Height: 50 + perktextheight,
+						Height: 40 + perktextheight,
 						Color: KDTextRedBG,
 						LineWidth: 5,
 						zIndex: 60.3,
 						alpha: 1.0
 					})
 				}
-				if (!perktextHasCJK) {
-					perktextsplits.forEach((tsplit) => {
-						DrawTextFitKD(tsplit, KDModalArea_x + (360 * i) + 30, textoffset, 300, KDBaseWhite, KDTextGray2, 16, "left");
-						textoffset += 25
-					})
-				} else {
-					textoffset += perktextheight;
-				}
+				textoffset += perktextheight;
 				
 				textoffset += 20
             })

--- a/Game/src/map/KinkyDungeonShrine.ts
+++ b/Game/src/map/KinkyDungeonShrine.ts
@@ -1000,35 +1000,52 @@ function KinkyDungeonDrawPerkOrb() {
 				
                 DrawTextFitKD(TextGet("KinkyDungeonStat" + KinkyDungeonStatsPresets[p].id), KDModalArea_x + (360 * i) + 25, textoffset, 300, perkraritycolor, (KinkyDungeonStatsPresets[p].cost < 0) ? KDTextRed1: KDTextGray2, 30, "left");
                 textoffset += 30
-                let perktextsplits = TextGet("KinkyDungeonStatDesc" + KinkyDungeonStatsPresets[p].id).split(" ");
-                perktextsplits = perktextsplits.reduce((prev, currword) => {
-                    let currentlength = prev[prev.length - 1].length;
-                    if ((currentlength + currword.length + 1) > 36 && (currentlength > 0)) {
-                        prev.push(currword)
-                    }
-                    else {
-                        prev[prev.length - 1] = (currentlength > 0) ? `${prev[prev.length - 1]} ${currword}` : currword
-                    }
-                    return prev;
-                }, ['']);
-                if (KinkyDungeonStatsPresets[p].cost < 0) {
-                    FillRectKD(kdcanvas, kdpixisprites, `bg_${i}_debuffperk_${p}`, {
-                        Left: KDModalArea_x + (360 * i) + 10,
-                        Top: textoffset - 55,
-                        Width: 330,
-                        Height: 50 + (perktextsplits.length * 25),
-                        Color: KDTextRedBG,
-                        LineWidth: 5,
-                        zIndex: 60.3,
-                        alpha: 1.0
-                    })
-                }
-                perktextsplits.forEach((tsplit) => {
-                    DrawTextFitKD(tsplit, KDModalArea_x + (360 * i) + 30, textoffset, 300, KDBaseWhite, KDTextGray2, 16, "left");
-                    textoffset += 25
-                })
-
-                textoffset += 20
+				let perktext = TextGet("KinkyDungeonStatDesc" + KinkyDungeonStatsPresets[p].id);
+				let perktextHasCJK = CharacterCheckerHasCJK(perktext);
+				let perktextsplits = [];
+				let perktextheight = 0;
+				if (perktextHasCJK) {
+					// Pixi can wrap CJK text character by character when word wrapping is enabled.
+					perktextheight = DrawTextFitKDgetHeight(perktext,
+						KDModalArea_x + (360 * i) + 30, textoffset, 300,
+						KDBaseWhite, KDTextGray2, 16, "left", 110, 1.0,
+						undefined, undefined, undefined, true, "top") + 20;
+				} else {
+					perktextsplits = perktext.split(" ");
+					perktextsplits = perktextsplits.reduce((prev, currword) => {
+						let currentlength = prev[prev.length - 1].length;
+						if ((currentlength + currword.length + 1) > 36 && (currentlength > 0)) {
+							prev.push(currword)
+						}
+						else {
+							prev[prev.length - 1] = (currentlength > 0) ? `${prev[prev.length - 1]} ${currword}` : currword
+						}
+						return prev;
+					}, ['']);
+					perktextheight = perktextsplits.length * 25;
+				}
+				if (KinkyDungeonStatsPresets[p].cost < 0) {
+					FillRectKD(kdcanvas, kdpixisprites, `bg_${i}_debuffperk_${p}`, {
+						Left: KDModalArea_x + (360 * i) + 10,
+						Top: textoffset - 55,
+						Width: 330,
+						Height: 50 + perktextheight,
+						Color: KDTextRedBG,
+						LineWidth: 5,
+						zIndex: 60.3,
+						alpha: 1.0
+					})
+				}
+				if (!perktextHasCJK) {
+					perktextsplits.forEach((tsplit) => {
+						DrawTextFitKD(tsplit, KDModalArea_x + (360 * i) + 30, textoffset, 300, KDBaseWhite, KDTextGray2, 16, "left");
+						textoffset += 25
+					})
+				} else {
+					textoffset += perktextheight;
+				}
+				
+				textoffset += 20
             })
             textoffset += 15
         }

--- a/Game/src/map/KinkyDungeonShrine.ts
+++ b/Game/src/map/KinkyDungeonShrine.ts
@@ -1001,11 +1001,8 @@ function KinkyDungeonDrawPerkOrb() {
                 DrawTextFitKD(TextGet("KinkyDungeonStat" + KinkyDungeonStatsPresets[p].id), KDModalArea_x + (360 * i) + 25, textoffset, 300, perkraritycolor, (KinkyDungeonStatsPresets[p].cost < 0) ? KDTextRed1: KDTextGray2, 30, "left");
                 textoffset += 20
 				let perktext = TextGet("KinkyDungeonStatDesc" + KinkyDungeonStatsPresets[p].id);
-				// Pixi wraps both word-separated and CJK text when word wrapping is enabled.
-				let perktextheight = DrawTextFitKDgetHeight(perktext,
-					KDModalArea_x + (360 * i) + 30, textoffset, 300,
-					KDBaseWhite, KDTextGray2, 16, "left", 110, 1.0,
-					undefined, undefined, undefined, true, "top", 22) + 20;
+
+				let perktextheight = DrawTextFitKDgetHeight(perktext, KDModalArea_x + (360 * i) + 30, textoffset, 300, KDBaseWhite, KDTextGray2, 16, "left", 110, 1.0, undefined, undefined, undefined, true, "top", 22) + 20;
 				if (KinkyDungeonStatsPresets[p].cost < 0) {
 					FillRectKD(kdcanvas, kdpixisprites, `bg_${i}_debuffperk_${p}`, {
 						Left: KDModalArea_x + (360 * i) + 10,


### PR DESCRIPTION
Fixes text layout issues for perk descriptions in the Perk Shrine selection screen.
The original word-splitting logic in `KinkyDungeonDrawPerkOrb` was unnecessarily complex, as line wrapping can be handled simply by using `DrawTextFitKDgetHeight`.
And add lineHeight in `KinkyDungeonDraw`

Old:
<img width="1476" height="837" alt="image" src="https://github.com/user-attachments/assets/1d6d18fc-d0ec-4cd4-8014-5e88f0d680a0" />
<img width="1478" height="846" alt="image" src="https://github.com/user-attachments/assets/ef502540-5ce6-4ba4-ac43-2610dee956c1" />

New:
<img width="1483" height="850" alt="image" src="https://github.com/user-attachments/assets/0480c330-367e-4ab5-a112-8741c93b6b73" />
<img width="1477" height="843" alt="image" src="https://github.com/user-attachments/assets/2ff7c447-143c-473b-aa21-8403bd824733" />