### PR TITLE
fix inventory tooltips not showing since ef18da543210fe086552fb6bae498c517152858b

### DIFF
--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -3494,7 +3494,7 @@ interface KDButtonParamData {
 	nonplayable?: boolean,
 	hoverData?: any,
 	onHover?: (button: KDButtonParamData) => void,
-  Hover?: any
+  Hover?: InventoryHoverObject
 }
 
 /** For most things use LastButtonsCache as buttons might not have been rendered yet this frame. Will lag a frame behind but eh. */
@@ -3537,7 +3537,7 @@ function DrawButtonKD (
 	HoveringText?:	string,
 	Disabled?:	boolean,
 	NoBorder?:	boolean,
-    Hover?:      Function,
+    Hover?:      InventoryHoverObject,
 ): void
 {
 	let params = {
@@ -3692,7 +3692,7 @@ function DrawButtonKDEx (
 	FontSize?:	number,
 	ShiftText?:	boolean,
 	options?:	ButtonOptions,
-  Hover?:      Function,
+  Hover?:      InventoryHoverObject,
 ): boolean
 {
 	let params = {
@@ -3868,7 +3868,7 @@ function DrawButtonKDExScroll (
 	FontSize?:	number,
 	ShiftText?:	boolean,
 	options?:	any,
-  Hover?:      Function,
+  Hover?:      InventoryHoverObject,
 ): boolean
 {
 
@@ -3954,7 +3954,7 @@ function DrawButtonKDExScrollTo (
 	FontSize?:	number,
 	ShiftText?:	boolean,
 	options?:	any,
-  Hover?:      Function,
+  Hover?:      InventoryHoverObject,
 ): boolean
 {
 
@@ -4036,6 +4036,7 @@ function DrawButtonKDExTo (
 	ShiftText?:	boolean,
 	options?:	any,
 	priority = 0,
+	Hover?: InventoryHoverObject,
 ): boolean
 {
 	let params = {
@@ -4050,12 +4051,19 @@ function DrawButtonKDExTo (
 		hotkeyPress: options?.hotkeyPress,
 		hoverData: options?.hoverData,
 		onHover: options?.onHover,
+		Hover,
 	};
 	let hover = ((MouseX >= Left) && (MouseX <= Left + Width) && (MouseY >= Top) && (MouseY <= Top + Height) && !CommonIsMobile && !Disabled);
 	if (hover) {
 		
-		if (!KDCurrentHoverButton || ((params.priority || 0) > (KDCurrentHoverButton.priority || 0))) {KDCurrentHoverButton = params;}
-		else Disabled = true;
+		if (!KDCurrentHoverButton || ((params.priority || 0) > (KDCurrentHoverButton.priority || 0))) {
+			KDCurrentHoverButton = params;
+			KDCurrentHoverBox = params;
+		}
+		else {
+			Disabled = true;
+			hover = false;
+		}
 	}
 	DrawButtonVisTo(Container, Left, Top, Width, Height, Label, Color, Image, HoveringText, Disabled, NoBorder, FillColor, FontSize, ShiftText, undefined, options?.zIndex, options);
 	KDButtonsCache[name] = params;

--- a/Game/src/item/KinkyDungeonInventory.ts
+++ b/Game/src/item/KinkyDungeonInventory.ts
@@ -1753,8 +1753,7 @@ function KDDrawInventoryContainer (
 								highlightcolor: highlightcolor,
 								hotkey: hk ? KDHotkeyToText(hk) : undefined,
 								hotkeyPress: hk,
-							//@ts-ignore // This should have a type assigned to it probably, but I do not know where to trace to make it happy. -Enraa
-							}, KDInventoryItemHover(filteredInventory[index].item)) && !tooltipitem) {
+							}, 0, KDInventoryItemHover(filteredInventory[index].item)) && !tooltipitem) {
 								tooltipitem = filteredInventory[index];
 							}
 							if (useIcons && filteredInventory[index].preview2)


### PR DESCRIPTION
ef18da543210fe086552fb6bae498c517152858b refactored `KDDrawInventoryContainer`. The change from `DrawButtonKDExScroll` to `DrawButtonKDExTo` broke tooltips for inventory items.

`DrawButtonKDExTo` did not have a `Hover` parameter. The return value of `KDInventoryItemHover` was passed as `priority` instead. I added the `Hover` parameter and shimmed in 0 as `priority`, and made it assign `KDCurrentHoverBox` like similar functions do. Tooltips are working for me now. I did not test anything outside of inventory items.

I also resolved Enraa's comment about `Hover` needing a type.