### PR TITLE
Add KinkyDungeonDrawStruggle to save

### DIFF
--- a/Game/src/base/KDTypeDefs.ts
+++ b/Game/src/base/KDTypeDefs.ts
@@ -3073,6 +3073,7 @@ interface KinkyDungeonSave {
 	perksmode?: number,
 	easymode?: number,
 	progressionmode?: string,
+	KinkyDungeonDrawStruggle: number,
 
 	faction: Record<string, Record<string, number>>;
 }

--- a/Game/src/base/KinkyDungeon.ts
+++ b/Game/src/base/KinkyDungeon.ts
@@ -7122,6 +7122,7 @@ function KinkyDungeonGenerateSaveData(): KinkyDungeonSave {
 	save.seed = KinkyDungeonSeed;
 	save.statchoice = Array.from(KinkyDungeonStatsChoice);
 	//save.mapIndex = KinkyDungeonMapIndex;
+	save.KinkyDungeonDrawStruggle = KinkyDungeonDrawStruggle;
 
 	save.flags = Array.from(KinkyDungeonFlags);
 	save.KDCommanderRoles = Array.from(KDCommanderRoles);
@@ -7303,6 +7304,7 @@ function KinkyDungeonLoadGame(String: string = "", kdloadconsent = false) {
 			if (saveData.rescued != undefined) KinkyDungeonRescued = saveData.rescued;
 			if (saveData.aid != undefined) KinkyDungeonAid = saveData.aid;
 			if (saveData.KDCurrentWorldSlot) KDCurrentWorldSlot = saveData.KDCurrentWorldSlot;
+			if (saveData.KinkyDungeonDrawStruggle !== undefined) KinkyDungeonDrawStruggle = saveData.KinkyDungeonDrawStruggle;
 
 
 			KDOrigStamina = KinkyDungeonStatStamina*10;

--- a/Game/src/base/game/KinkyDungeonHUD.ts
+++ b/Game/src/base/game/KinkyDungeonHUD.ts
@@ -39,20 +39,20 @@ let KinkyDungeonStruggleGroupsBase = [
 	"ItemFeet",
 	"ItemBoots",
 ];
-let KDDrawStruggleEnum = {
-	ALMOSTALL: 1,
-	MOST: 2,
-	FULL: 0,
-	STRUGGLE: 3,
-	NONE: 4,
+enum KDDrawStruggleEnum {
+	ALMOSTALL = 1,
+	MOST = 2,
+	FULL = 0,
+	STRUGGLE = 3,
+	NONE = 4,
 };
 let KDDrawMaxStruggle = 4;
 let KDDrawStruggleIcon = {
-	[KDDrawStruggleEnum["ALMOSTALL"]]: "AlmostAll",
-	[KDDrawStruggleEnum["MOST"]]: "Most",
-	[KDDrawStruggleEnum["FULL"]]: "Full",
-	[KDDrawStruggleEnum["STRUGGLE"]]: "Struggle",
-	[KDDrawStruggleEnum["NONE"]]: "True",
+	[KDDrawStruggleEnum.ALMOSTALL]: "AlmostAll",
+	[KDDrawStruggleEnum.MOST]: "Most",
+	[KDDrawStruggleEnum.FULL]: "Full",
+	[KDDrawStruggleEnum.STRUGGLE]: "Struggle",
+	[KDDrawStruggleEnum.NONE]: "True",
 };
 let KinkyDungeonDrawStruggle = KDDrawStruggleEnum.ALMOSTALL;
 let KDPlayerSetPose = false;


### PR DESCRIPTION
https://discord.com/channels/938203644023685181/1011351954120777771/1546627675605700689

I first tried putting it in `KDGameData`. That caused existing saves to have a bug where `KDGameData.DrawStruggle` appeared to became undefined after `KinkyDungeonLoadGame` despite having a proper default value in `KDGameDataBase`, resulting in `NaN` after the `+= 1` from clicking the button. I was not interested in debugging that, so I made it top-level in the save.

I also turned the enum into a real enum.