### PR TITLE
Let Psychics and Telekinetics use doorknobs

### DIFF
--- a/Game/src/map/KinkyDungeonTilesList.ts
+++ b/Game/src/map/KinkyDungeonTilesList.ts
@@ -1854,15 +1854,15 @@ function KDAttemptDoor(moveX: number, moveY: number) {
 		|| !KinkyDungeonIsHandsBound(true, true, 0.45);
 	if (!open) {
 		if (KinkyDungeonCanUseFeet(false)) {
-		    KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobFeet"), KDBaseMint, 2);
-		    open = true;
-		  } else if (KinkyDungeonStatsChoice.get("Psychic")) {
-		    KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobPsychic"), KDBaseMint, 2);
-		    open = true;
-		  } else if (KinkyDungeonPlayerDamage.telekinetic) {
-		    KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobTelekinetic"), KDBaseMint, 2);
-		    open = true;
-		  } else {
+			KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobFeet"), KDBaseMint, 2);
+			open = true;
+		} else if (KinkyDungeonStatsChoice.get("Psychic")) {
+			KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobPsychic"), KDBaseMint, 2);
+			open = true;
+		} else if (KinkyDungeonPlayerDamage.telekinetic) {
+			KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobTelekinetic"), KDBaseMint, 2);
+			open = true;
+		} else {
 			let grace = 0;
 			if (KinkyDungeonFlags.get("failUnfairFirst") && !KinkyDungeonFlags.get("failUnfair")) grace = 0.4;
 			let armsbound = KinkyDungeonIsArmsBound(true, true);

--- a/Game/src/map/KinkyDungeonTilesList.ts
+++ b/Game/src/map/KinkyDungeonTilesList.ts
@@ -1854,9 +1854,15 @@ function KDAttemptDoor(moveX: number, moveY: number) {
 		|| !KinkyDungeonIsHandsBound(true, true, 0.45);
 	if (!open) {
 		if (KinkyDungeonCanUseFeet(false)) {
-			KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobFeet"), KDBaseMint, 2);
-			open = true;
-		} else {
+		    KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobFeet"), KDBaseMint, 2);
+		    open = true;
+		  } else if (KinkyDungeonStatsChoice.get("Psychic")) {
+		    KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobPsychic"), KDBaseMint, 2);
+		    open = true;
+		  } else if (KinkyDungeonPlayerDamage.telekinetic) {
+		    KinkyDungeonSendActionMessage(10, TextGet("KDDoorknobTelekinetic"), KDBaseMint, 2);
+		    open = true;
+		  } else {
 			let grace = 0;
 			if (KinkyDungeonFlags.get("failUnfairFirst") && !KinkyDungeonFlags.get("failUnfair")) grace = 0.4;
 			let armsbound = KinkyDungeonIsArmsBound(true, true);

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -526,7 +526,9 @@ KDDoorknobAttract,"Someone hears you banging and opens the door from the other s
 KDDoorknobAttractArms,"Someone notices you fiddling with the door and opens it from the other side!"
 KDDoorknobSuccess,"The door squeaks open as the latch wasn't fully engaged."
 KDDoorknobSuccessArms,"You grab the doorknob with your wrists and flex it open."
-KDDoorknobFeet,You use your flexible feet to open the door.
+KDDoorknobFeet,"You use your flexible feet to open the door."
+KDDoorknobPsychic,"You use your psychic abilities to open the door."
+KDDoorknobTelekinetic,"You use your telekinetic abilities to open the door."
 
 KinkyDungeonStatSelfMiscast,"Poor Technique"
 KinkyDungeonStatDescSelfMiscast,"Instead of fizzling, most miscasted projectiles and AoE spells will target you instead."


### PR DESCRIPTION
Allows psychics and telekinetics to use doorknobs.
This is not about picking locks, but just opening doors that are already unlocked.