### PR TITLE
Display Stand spell balance

### DIFF
--- a/Game/src/magic/KinkyDungeonMagicCode.ts
+++ b/Game/src/magic/KinkyDungeonMagicCode.ts
@@ -800,7 +800,6 @@ let KinkyDungeonSpellSpecials: Record<string, KDSpellSpecialCode> = {
 					KinkyDungeonSendActionMessage(3, TextGet("KinkyDungeonSpellCast"+spell.name, KDGetGenericDialogueParams(entity, en)), "#88AAFF", 2 + (spell.channel ? spell.channel - 1 : 0));
 
 					KDChangeMana(spell.name, "spell", "cast", -KinkyDungeonGetManaCost(spell));
-					KDChangeCharge(spell.name, "spell", "cast", 0.05);
 					return "Cast";
 				}
 				

--- a/Game/src/magic/KinkyDungeonMagicList.ts
+++ b/Game/src/magic/KinkyDungeonMagicList.ts
@@ -1379,7 +1379,7 @@ let KinkyDungeonSpellList: Record<string, spell[]> = { // List of spells you can
 
 		{name: "DisplayStand", prerequisite: "ApprenticeMetal", tags: ["metal", "summon", "utility", "petsuit"], sfx: "Magic", school: "Conjure", manacost: 1, components: [], level:1,
 			type:"special", special: "DisplayStand",
-			onhit:"", time:0, power: 0.0, range: 2.99, size: 1, aoe: 0.5, damage: "glue"},
+			onhit:"", time:0, power: 0.0, range: 4.5, size: 1, aoe: 0.5, damage: "glue"},
 
 		{name: "RopeBoltLaunch", tags: ["rope", "bolt", "binding", "offense"], prerequisite: "ApprenticeRope", sfx: "MagicSlash", school: "Conjure",
 			manacost: 3, components: ["Verbal"], projectileTargeting: true, noTargetPlayer: true, CastInWalls: true, level:1, type:"inert", onhit:"aoe", time: 5, delay: 3, power: 1, range: 8, meleeOrigin: true, size: 1, lifetime: 1, damage: "inert", noMiscast: false, castDuringDelay: true, noCastOnHit: true,

--- a/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
+++ b/Screens/MiniGame/KinkyDungeon/Text_KinkyDungeon.csv
@@ -7053,7 +7053,7 @@ KinkyDungeonSpellCastSelfPetsuit,"You watch in horror as your own creation lunge
 KinkyDungeonSpellTargetPetsuit,Choose a helpless target
 
 KinkyDungeonSpellDisplayStand,Conjure Display Stand
-KinkyDungeonSpellDescriptionDisplayStand,"Target only Helpless enemies. Creates a fixture that increases passive mana recovery from mana pool, restores 50 Charge, and makes nearby enemies take 50% more charm/psychic damage."
+KinkyDungeonSpellDescriptionDisplayStand,"Target only Helpless enemies. Creates a fixture that increases passive mana recovery from mana pool and makes nearby enemies take 50% more charm/psychic damage."
 KinkyDungeonSpellCastDisplayStand,"You conjure a fixture to hold your helpless target in place!"
 KinkyDungeonSpellCastSelfDisplayStand,"You watch in horror as your own creation encircles you, locking you in place with a hefty click!"
 KinkyDungeonSpellTargetDisplayStand,Choose a helpless target


### PR DESCRIPTION
Removes Charge gain from the Display Stand spell, but increases its range 1.5x as compensation.

**Motivation:**
50 charge per mob trivializes Charge regain, making power crystals (ancient power source) unimportant and the Lost Technology debuff perk a freebie.
The cost of the spell is negligible: 10 mana by default, but can be reduced to free by Wizard abilities or Mana Efficiency enchantments. Works on any weak low-level defeated enemy. For this to be able to conjure effectively 1/5 of an Ancient Power Source, repeatably, is exploitable.
Thematically, instantaneous Charge gain from the spell does not make much sense either.

**Compensation:**
To avoid making this a pure nerf, increased the cast range. This helps lean further into the secondary utility of the spell.
Primarily, it is about buffing friendly mana regen and increasing damage to nearby enemies.
But secondarily, it can be used to finish (capture) defeated enemies at a distance without having to go next to them, preventing their recovery and re-entry into a still-ongoing fight. This is useful when there are still dangerous enemies near the defeated one. The moderately increased range should help with that.